### PR TITLE
Starting forward slash issue on Laravel 4.1

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -385,7 +385,11 @@ class LaravelLocalization
 	public function getRouteNameFromAPath($path)
 	{
 		$path = str_replace(url(), "", $path);
-	    $path = str_replace("/".$this->currentLanguage."/","",$path);
+		if($path[0] !== '/')
+		{
+			$path = '/' . $path;
+		}
+		$path = str_replace('/' . $this->currentLanguage . '/', '', $path);
 	    $path = trim($path,"/");
 
 	    foreach ($this->translatedRoutes as $route) {


### PR DESCRIPTION
Spotted an issue with latest version of Laravel (maybe since version 4.1.6? not sure) when generating the links in the language bar caused by a '/' not present anymore in the beginning of the $path variable (and therefore no str_replace is happening creating links like 'en/acerca').
In a DRY way I choose to add a starting forward slash when $path doesn't start with it.
