### PR TITLE
Added optionnal $locale parameter to setLanguage()

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -77,7 +77,7 @@ class LaravelLocalization
 
 	/**
 	 * Set and return current language
-	 * @param  string $locale	Language to set the App to (optionnal)
+	 * @param  string $locale	Language to set the App to (optional)
 	 * @return String 			Returns language (if route has any) or null (if route has not a language)
 	 */
 	public function setLanguage($locale = null)


### PR DESCRIPTION
I needed to set the language manually, so I thought it was a good idea to be able to set it from the setLanguage() function by adding a $locale parameter.
