### PR TITLE
Fixes compatibility with Laravel 4.1

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -220,15 +220,15 @@ class LaravelLocalization
 				// the system will take the same
 				global $app;
 				$router = $app['router'];
-				if (method_exists($router, 'getCurrentRoute'))
-				{
-					// Laravel 4.0
-					$attributes = $router->getCurrentRoute()->getParameters();
-				}
-				else
+				if(App::make('laravel-localization.4.1'))
 				{
 					// Laravel 4.1
 					$attributes = $router->current()->parameters();
+				}
+				else
+				{
+					// Laravel 4.0
+					$attributes = $router->getCurrentRoute()->getParameters();
 				}
 			}
 		}
@@ -450,15 +450,15 @@ Route::filter('LaravelLocalizationRoutes', function()
 {
 	global $app;
 	$router = $app['router'];
-	if (method_exists($router, 'getCurrentRoute'))
-	{
-		// Laravel 4.0
-		$routeName = $app['laravellocalization']->getRouteNameFromAPath($router->getCurrentRoute()->getPath());
-	}
-	else
+	if(App::make('laravel-localization.4.1'))
 	{
 		// Laravel 4.1
 		$routeName = $app['laravellocalization']->getRouteNameFromAPath($router->current()->uri());
+	}
+	else
+	{
+		// Laravel 4.0
+		$routeName = $app['laravellocalization']->getRouteNameFromAPath($router->getCurrentRoute()->getPath());
 	}
 	$app['laravellocalization']->setRouteName($routeName);
 	return;

--- a/src/Mcamara/LaravelLocalization/LaravelLocalizationServiceProvider.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalizationServiceProvider.php
@@ -19,6 +19,9 @@ class LaravelLocalizationServiceProvider extends ServiceProvider {
 	public function boot()
 	{
 		$this->package('mcamara/laravel-localization');
+		
+		//define a constant that the rest of the package can use to conditionally use pieces of Laravel 4.1.x vs. 4.0.x
+		$this->app['laravel-localization.4.1'] = version_compare(\Illuminate\Foundation\Application::VERSION, '4.1') > -1;
 	}
 
 	/**


### PR DESCRIPTION
if (method_exists($router, 'getCurrentRoute')){…} fails to determine if we are using Laravel 4.1.x or 4.0.x.
Instead, we can use a constant de identify the version...
