### PR TITLE
getLocalizedURL() fix for urls that contain query strings

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -247,7 +247,7 @@ class LaravelLocalization
 				// the system would return the translated one
 				return $this->getURLFromRouteNameTranslated($locale);
 			}
-			$url = Request::url();
+			$url = Request::fullUrl();
 		}
 
 		$parsed_url = parse_url($url);


### PR DESCRIPTION
Small change for the getLocalizedURL() to localize correctly current urls that contain query strings.
