### PR TITLE
Fix for typo in getURLFromRouteNameTranslated

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -354,7 +354,7 @@ class LaravelLocalization
 			return false;
 		}
 
-		if (empty($transKeyNames))
+		if (empty($transKeysNames))
 		{
 			// if translation key name is not given
 			// the system would try to get the current one...


### PR DESCRIPTION
getURLFromRouteNameTranslated always returned false as $transKeyName wasn't set
