### PR TITLE
Added extra slash

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -386,7 +386,7 @@ class LaravelLocalization
 		$route = "";
 		if (!($locale === $this->defaultLocale && $this->hideDefaultLocaleInURL()))
 		{
-			$route = $locale;
+			$route = '/'.$locale;
 		}
 		
 		foreach ($transKeysNames as $transKeyName)


### PR DESCRIPTION
Prevents from adding duplicate locale prefix to url. Without this slash the returned double locale prefix:

http://example.com/de/de/{named_route}
http://example.com/en/en/{named_route}
