### PR TITLE
Removed execution of code inside the LaravelLocalization class.

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -10,8 +10,6 @@ use Cookie;
 use App;
 use View;
 use Config;
-use Redirect;
-use Route;
 
 class LaravelLocalization
 {
@@ -952,47 +950,6 @@ class LaravelLocalization
 	}
 
 }
-
-Route::filter('LaravelLocalizationRedirectFilter', function()
-{
-	global $app;
-	$currentLocale = $app['laravellocalization']->getCurrentLocale();
-	$defaultLocale = $app['laravellocalization']->getDefault();
-	$params = explode('/', Request::path());
-	if (count($params) > 0)
-	{
-		$localeCode = $params[0];
-		$locales = $app['laravellocalization']->getSupportedLocales();
-
-		if (!empty($locales[$localeCode]))
-		{
-			if ($localeCode === $defaultLocale && $app['laravellocalization']->hideDefaultLocaleInURL())
-			{
-				return Redirect::to($app['laravellocalization']->getNonLocalizedURL(), 307)->header('Vary','Accept-Language');
-			}
-		}
-		else if ($currentLocale !== $defaultLocale || !$app['laravellocalization']->hideDefaultLocaleInURL())
-		{
-			// If the current url does not contain any locale
-			// The system redirect the user to the very same url "localized"
-			// we use the current locale to redirect him
-			return Redirect::to($app['laravellocalization']->getLocalizedURL(), 307)->header('Vary','Accept-Language');
-		}
-	}
-});
-
-/**
- * 	This filter would set the translated route name
- */
-Route::filter('LaravelLocalizationRoutes', function()
-{
-	global $app;
-	$router = $app['router'];
-	$routeName = $app['laravellocalization']->getRouteNameFromAPath($router->current()->uri());
-
-	$app['laravellocalization']->setRouteName($routeName);
-	return;
-});
 
 class UnsupportedLocaleException extends Exception
 {

--- a/src/Mcamara/LaravelLocalization/LaravelLocalizationServiceProvider.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalizationServiceProvider.php
@@ -1,6 +1,9 @@
 <?php namespace Mcamara\LaravelLocalization;
 
 use Illuminate\Support\ServiceProvider;
+use Route;
+use Request;
+use Redirect;
 
 class LaravelLocalizationServiceProvider extends ServiceProvider {
 
@@ -28,6 +31,48 @@ class LaravelLocalizationServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
+
+        Route::filter('LaravelLocalizationRedirectFilter', function()
+        {
+            global $app;
+            $currentLocale = $app['laravellocalization']->getCurrentLocale();
+            $defaultLocale = $app['laravellocalization']->getDefault();
+            $params = explode('/', Request::path());
+            if (count($params) > 0)
+            {
+                $localeCode = $params[0];
+                $locales = $app['laravellocalization']->getSupportedLocales();
+
+                if (!empty($locales[$localeCode]))
+                {
+                    if ($localeCode === $defaultLocale && $app['laravellocalization']->hideDefaultLocaleInURL())
+                    {
+                        return Redirect::to($app['laravellocalization']->getNonLocalizedURL(), 307)->header('Vary','Accept-Language');
+                    }
+                }
+                else if ($currentLocale !== $defaultLocale || !$app['laravellocalization']->hideDefaultLocaleInURL())
+                {
+                    // If the current url does not contain any locale
+                    // The system redirect the user to the very same url "localized"
+                    // we use the current locale to redirect him
+                    return Redirect::to($app['laravellocalization']->getLocalizedURL(), 307)->header('Vary','Accept-Language');
+                }
+            }
+        });
+
+        /**
+         * 	This filter would set the translated route name
+         */
+        Route::filter('LaravelLocalizationRoutes', function()
+        {
+            global $app;
+            $router = $app['router'];
+            $routeName = $app['laravellocalization']->getRouteNameFromAPath($router->current()->uri());
+
+            $app['laravellocalization']->setRouteName($routeName);
+            return;
+        });
+
 		$this->app['config']->package('mcamara/laravel-localization', __DIR__.'/../config');
 
 		$this->app['laravellocalization'] = $this->app->share(function($app)


### PR DESCRIPTION
Currently it is not possible to mock the class LaravelLocalization because the filters are added to the bottom of the class.

This problem is solved by removing the execution of this code to the service provider.

PS. The package is the best!
