### PR TITLE
Re-flashing data before redirects

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalizationServiceProvider.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalizationServiceProvider.php
@@ -47,11 +47,17 @@ class LaravelLocalizationServiceProvider extends ServiceProvider {
                 {
                     if ($localeCode === $defaultLocale && $app['laravellocalization']->hideDefaultLocaleInURL())
                     {
+                    	// Save any flashed data for redirect
+                    	Session::reflash();
+
                         return Redirect::to($app['laravellocalization']->getNonLocalizedURL(), 307)->header('Vary','Accept-Language');
                     }
                 }
                 else if ($currentLocale !== $defaultLocale || !$app['laravellocalization']->hideDefaultLocaleInURL())
                 {
+                    // Save any flashed data for redirect
+                    Session::reflash();
+
                     // If the current url does not contain any locale
                     // The system redirect the user to the very same url "localized"
                     // we use the current locale to redirect him


### PR DESCRIPTION
Adding Session::reflash() calls before redirecting within the route filter. This should preserve any previously flashed data.

I haven't been able to test yet, but this I believe this fixes #116 and #120
