### PR TITLE
New way to obtain Accept-language Header

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -886,7 +886,7 @@ class LaravelLocalization
 			{
 				$option = array_map('trim', explode(';', $option));
 
-				$l = strtolower($option[0]);
+				$l = $option[0];
 				if (isset($option[1]))
 				{
 					$q = (float) str_replace('q=', '', $option[1]);
@@ -943,6 +943,12 @@ class LaravelLocalization
 				return array_shift($supported);
 			}
 		}
+		
+	        if (isset($_SERVER['HTTP_ACCEPT_LANGUAGE']))
+	        {
+	            if ($_SERVER['HTTP_ACCEPT_LANGUAGE'] != '')
+	                return locale_accept_from_http($_SERVER['HTTP_ACCEPT_LANGUAGE']);
+	        }		
 
 		if (Request::server('REMOTE_HOST'))
 		{


### PR DESCRIPTION
Hi Marc! 

Now, I need languages with country code (es-ES, es-CO, etc). I have seen that server negotiation is not working well at my machine and I was searching solutions. I add a new method to get Accept-language header

I obtain the Accept-language with all browsers, before i didn't

Changes:
Add this method http://php.net/manual/es/locale.acceptfromhttp.php
Delete strtolower line 889 (the good format is es-ES, not es-es)
