### PR TITLE
Fixes undefined function fatal error because of namespace

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -948,7 +948,7 @@ class LaravelLocalization
 	        {
 	            if ($_SERVER['HTTP_ACCEPT_LANGUAGE'] != '')
 	            {
-                	$http_accept_language = locale_accept_from_http($_SERVER['HTTP_ACCEPT_LANGUAGE']);
+                	$http_accept_language = \locale_accept_from_http($_SERVER['HTTP_ACCEPT_LANGUAGE']);
                 	if (in_array($http_accept_language, $supported))
                 	{
                     		return $http_accept_language;


### PR DESCRIPTION
Fixes the following error:

```
Call to undefined function Mcamara\LaravelLocalization\locale_accept_from_http()' in /home/.../vendor/mcamara/laravel-localization/src/Mcamara/LaravelLocalization/LaravelLocalization.php:951
```
