### PR TITLE
Use the router from the IOC container

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalizationServiceProvider.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalizationServiceProvider.php
@@ -33,7 +33,7 @@ class LaravelLocalizationServiceProvider extends ServiceProvider {
 	public function register()
 	{
         $app = $this->app;
-        Route::filter('LaravelLocalizationRedirectFilter', function() use($app)
+        $app->router->filter('LaravelLocalizationRedirectFilter', function() use($app)
         {
             $currentLocale = $app['laravellocalization']->getCurrentLocale();
             $defaultLocale = $app['laravellocalization']->getDefault();
@@ -72,7 +72,7 @@ class LaravelLocalizationServiceProvider extends ServiceProvider {
         /**
          * 	This filter would set the translated route name
          */
-        Route::filter('LaravelLocalizationRoutes', function()
+        $app->router->filter('LaravelLocalizationRoutes', function()
         {
             $app = $this->app;
             $routeName = $app['laravellocalization']->getRouteNameFromAPath($app['router']->current()->uri());


### PR DESCRIPTION
I noticed that if you want to use this package with another package that redefines the router (like [Dingo/api](https://github.com/dingo/api)), using the facade to define the filters does not work. 