### PR TITLE
Fix URL without trailing slash

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -740,7 +740,12 @@ class LaravelLocalization {
         {
             $attributes = [ ];
             $parse = parse_url($url);
-            $parse = explode("/", $parse[ 'path' ]);
+            if ( isset( $parse[ 'path' ] ) ) {
+                $parse = explode("/", $parse[ 'path' ]);
+            }
+            else {
+                $parse = [];
+            }
             $url = [ ];
             foreach ( $parse as $segment )
             {

--- a/tests/LocalizerTests.php
+++ b/tests/LocalizerTests.php
@@ -5,7 +5,8 @@ use Illuminate\Routing\RouteCollection;
 
 class LocalizerTests extends \Orchestra\Testbench\TestCase {
 
-    protected $test_url = 'http://localhost/';
+    protected $test_url  = 'http://localhost/';
+    protected $test_url2 = 'http://localhost';
 
     protected $supportedLocales = [ ];
 
@@ -140,6 +141,12 @@ class LocalizerTests extends \Orchestra\Testbench\TestCase {
     {
         $this->assertEquals(
             $this->test_url . app('laravellocalization')->getCurrentLocale(),
+            app('laravellocalization')->localizeURL()
+        );
+
+        // Missing trailing slash in a URL
+        $this->assertEquals(
+            $this->test_url2 . '/' . app('laravellocalization')->getCurrentLocale(),
             app('laravellocalization')->localizeURL()
         );
 


### PR DESCRIPTION
Warning when performing a parse_url($url) on a url without a trailing slash.
Eg: http://www.google.fr