### PR TITLE
Fix LanguageNegotiator Bug

### DIFF
--- a/src/Mcamara/LaravelLocalization/LanguageNegotiator.php
+++ b/src/Mcamara/LaravelLocalization/LanguageNegotiator.php
@@ -63,7 +63,9 @@ class LanguageNegotiator {
         // If any (i.e. "*") is acceptable, return the first supported format
         if ( isset( $matches[ '*' ] ) )
         {
-            return array_shift($this->supportedLanguages);
+            reset($this->supportedLanguages);
+
+            return key($array);
         }
 
         if ( class_exists('Locale') && !empty( $_SERVER[ 'HTTP_ACCEPT_LANGUAGE' ] ) )


### PR DESCRIPTION
if HTTP_ACCEPT_LANGUAGE is `*`, array_shift returns the full array instead of the language key. This results in an error:

```
production.ERROR: exception 'ErrorException' with message 'Illegal offset type in isset or empty' in /home/poolhero/poolhero/vendor/mcamara/laravel-localization/src/Mcamara/LaravelLocalization/LaravelLocalization.php:502
```
```
#0 vendor/mcamara/laravel-localization/src/Mcamara/LaravelLocalization/LaravelLocalization.php(502): Illuminate\Foundation\Bootstrap\HandleExceptions->handleError(2, 'Illegal offset ...', '/home/...', 502, Array)
#1 vendor/mcamara/laravel-localization/src/Mcamara/LaravelLocalization/LaravelLocalization.php(216): Mcamara\LaravelLocalization\LaravelLocalization->checkLocaleInSupportedLocales(Array)
#2 vendor/mcamara/laravel-localization/src/Mcamara/LaravelLocalization/Middleware/LaravelLocalizationRedirectFilter.php(41): Mcamara\LaravelLocalization\LaravelLocalization->getLocalizedURL()
#3 vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(125): Mcamara\LaravelLocalization\Middleware\LaravelLocalizationRedirectFilter->handle(Object(Illuminate\Http\Request), Object(Closure))
```