### PR TITLE
Fix broken translated routes

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -223,11 +223,6 @@ class LaravelLocalization {
             $attributes = $this->extractAttributes($url);
         }
 
-        if ( $locale && $translatedRoute = $this->findTranslatedRouteByUrl($url, $attributes, $this->currentLocale) )
-        {
-            return $this->getURLFromRouteNameTranslated($locale, $translatedRoute, $attributes);
-        }
-
         if ( empty( $url ) )
         {
             if ( !empty( $this->routeName ) )
@@ -237,6 +232,11 @@ class LaravelLocalization {
 
             $url = $this->request->fullUrl();
 
+        }
+        
+        if ( $locale && $translatedRoute = $this->findTranslatedRouteByUrl($url, $attributes, $this->currentLocale) )
+        {
+            return $this->getURLFromRouteNameTranslated($locale, $translatedRoute, $attributes);
         }
 
         $base_path = $this->request->getBaseUrl();


### PR DESCRIPTION
Routes are not translated properly if the $url passed to getLocalizedURL is NULL because the if ( empty( $url ) ) check doesn't happen until after findTranslatedRouteByUrl().  This edit simply moves the if ( empty( $url ) ) logic above.