### PR TITLE
Fixing incorrect Vary redirect HTTP header

### DIFF
--- a/src/Mcamara/LaravelLocalization/Middleware/LaravelLocalizationRedirectFilter.php
+++ b/src/Mcamara/LaravelLocalization/Middleware/LaravelLocalizationRedirectFilter.php
@@ -46,7 +46,7 @@ class LaravelLocalizationRedirectFilter implements Middleware {
                 // Save any flashed data for redirect
                 app('session')->reflash();
 
-                return new RedirectResponse($redirection, 307, [ 'Vary', 'Accept-Language' ]);
+                return new RedirectResponse($redirection, 307, [ 'Vary' => 'Accept-Language' ]);
             }
         }
 

--- a/src/Mcamara/LaravelLocalization/Middleware/LocaleCookieRedirect.php
+++ b/src/Mcamara/LaravelLocalization/Middleware/LocaleCookieRedirect.php
@@ -32,7 +32,7 @@ class LocaleCookieRedirect implements Middleware {
             app('session')->reflash();
             $redirection = app('laravellocalization')->getLocalizedURL($locale);
 
-            return new RedirectResponse($redirection, 302, [ 'Vary', 'Accept-Language' ]);
+            return new RedirectResponse($redirection, 302, [ 'Vary' => 'Accept-Language' ]);
         }
 
         return $next($request);

--- a/src/Mcamara/LaravelLocalization/Middleware/LocaleSessionRedirect.php
+++ b/src/Mcamara/LaravelLocalization/Middleware/LocaleSessionRedirect.php
@@ -31,7 +31,7 @@ class LocaleSessionRedirect implements Middleware {
             app('session')->reflash();
             $redirection = app('laravellocalization')->getLocalizedURL($locale);
 
-            return new RedirectResponse($redirection, 302, [ 'Vary', 'Accept-Language' ]);
+            return new RedirectResponse($redirection, 302, [ 'Vary' => 'Accept-Language' ]);
         }
 
         return $next($request);


### PR DESCRIPTION
I believe that true intention was to send `Vary: Accept-Language` header instead of 
`0: Vary`
`1: Accept-Language`
This bug may potentially impact SEO on sites using this package.
