### PR TITLE
Travis - test PHP 7.0, use faster containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: php
 
+sudo: false
+
 php:
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 before_script:


### PR DESCRIPTION
Travis can test against PHP 7.0

The test scripts do not need `sudo`, so we can use the newer/faster test servers.