### PR TITLE
fix if condition to not overwrite $locale

### DIFF
--- a/src/Mcamara/LaravelLocalization/Middleware/LocaleCookieRedirect.php
+++ b/src/Mcamara/LaravelLocalization/Middleware/LocaleCookieRedirect.php
@@ -17,7 +17,7 @@ class LocaleCookieRedirect {
         $params = explode('/', $request->path());
         $locale = $request->cookie('locale', false);
 
-        if ( count($params) > 0 && $locale = app('laravellocalization')->checkLocaleInSupportedLocales($params[ 0 ]) )
+        if ( count($params) > 0 && app('laravellocalization')->checkLocaleInSupportedLocales($params[ 0 ]) )
         {
             cookie('locale', $params[ 0 ]);
 

--- a/src/Mcamara/LaravelLocalization/Middleware/LocaleSessionRedirect.php
+++ b/src/Mcamara/LaravelLocalization/Middleware/LocaleSessionRedirect.php
@@ -17,7 +17,7 @@ class LocaleSessionRedirect {
         $params = explode('/', $request->path());
         $locale = session('locale', false);
 
-        if ( count($params) > 0 && $locale = app('laravellocalization')->checkLocaleInSupportedLocales($params[ 0 ]) )
+        if ( count($params) > 0 && app('laravellocalization')->checkLocaleInSupportedLocales($params[ 0 ]) )
         {
             session([ 'locale' => $params[ 0 ] ]);
 


### PR DESCRIPTION
Fix the Problem where the locale was overwritten.

Already discussed in https://github.com/mcamara/laravel-localization/issues/281

This was already fixed in version 1.0 (https://github.com/mcamara/laravel-localization/pull/286). 