### PR TITLE
Change the way the ServiceProvider registers the class

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalizationServiceProvider.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalizationServiceProvider.php
@@ -47,11 +47,13 @@ class LaravelLocalizationServiceProvider extends ServiceProvider {
             $packageConfigFile, 'laravellocalization'
         );
 
-        $this->app[ 'laravellocalization' ] = $this->app->share(
+        $this->app[ LaravelLocalization::class ] = $this->app->share(
             function ()
             {
                 return new LaravelLocalization();
             }
         );
+
+        $this->app->alias(LaravelLocalization::class, 'laravellocalization');
     }
 }


### PR DESCRIPTION
When using constructor injection with the class name, each time a new instance is created.
With this change, the service provider registers itself using the full class name. This makes sure the same instance is used each time.

Also added an alias to keep backwards-compatibility.