### PR TITLE
duplicate all routes for unit testing

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -908,4 +908,28 @@ class LaravelLocalization {
 
         return $url;
     }
+
+    /**
+     * Duplicate all routes that have the "setLocale" prefix (detected by "/" as the first char)
+     */
+    public function setUnitTestingRoutes()
+    {
+        $langs = array_keys($this->getSupportedLocales());
+        foreach ($this->router->getRoutes() as $r) {
+            foreach ($langs as $lang) {
+                $action = $r->getAction();
+                if ($action['prefix'][0] == '/' ) {
+                    $newUri = str_replace($action['prefix'] . '/', '',  '/' . $r->getUri());
+                    $action['prefix'] = $lang . $action['prefix'];
+                    if (in_array('GET', $r->getMethods()) && in_array('POST', $r->getMethods())) {
+                        $this->router->any($newUri, $action);
+                    }
+                    else {
+                        $this->router->{strtolower($r->getMethods()[0])}($newUri, $action);
+                    }
+                }
+            }
+            
+        }
+    }
 }


### PR DESCRIPTION
Possible fix for https://github.com/mcamara/laravel-localization/issues/161

I use this in my route definition:
`Route::group(['prefix' => LaravelLocalization::setLocale() ? LaravelLocalization::setLocale() : '/' , 'middleware' => [ 'localeSessionRedirect', 'localizationRedirect' ]], function() {`