### PR TITLE
fix hideDefaultLocaleInURL problem

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -283,7 +283,10 @@ class LaravelLocalization {
             return $this->getURLFromRouteNameTranslated($locale, $translatedRoute, $attributes);
         }
 
-        $parsed_url[ 'path' ] = $locale . '/' . ltrim(ltrim($base_path, '/') . '/' . $parsed_url[ 'path' ], '/');
+        if ( !empty( $locale ) )
+        {
+            $parsed_url[ 'path' ] = $locale . '/' . ltrim(ltrim($base_path, '/') . '/' . $parsed_url[ 'path' ], '/');
+        }
 
         //Make sure that the pass path is returned with a leading slash only if it come in with one.
         if ( starts_with($path, '/') === true )

--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -283,11 +283,7 @@ class LaravelLocalization {
             return $this->getURLFromRouteNameTranslated($locale, $translatedRoute, $attributes);
         }
 
-        if ( !empty( $locale ) && ( $locale != $this->defaultLocale || !$this->hideDefaultLocaleInURL() ) )
-        {
-            $parsed_url[ 'path' ] = $locale . '/' . ltrim($parsed_url[ 'path' ], '/');
-        }
-        $parsed_url[ 'path' ] = ltrim(ltrim($base_path, '/') . '/' . $parsed_url[ 'path' ], '/');
+        $parsed_url[ 'path' ] = $locale . '/' . ltrim(ltrim($base_path, '/') . '/' . $parsed_url[ 'path' ], '/');
 
         //Make sure that the pass path is returned with a leading slash only if it come in with one.
         if ( starts_with($path, '/') === true )


### PR DESCRIPTION
## You can fix it by going to this file 
`/vendor/mcamara/laravel-localization/src/Mcamara/LaravelLocalization/LaravelLocalization.php`
## and search for 
`$parsed_url[ 'path' ] = $locale . '/' . ltrim($parsed_url[ 'path' ], '/');` 
## you will find something like this

`if ( !empty( $locale ) && ( $locale != $this->defaultLocale || !$this->hideDefaultLocaleInURL() ) )
        {
            $parsed_url[ 'path' ] = $locale . '/' . ltrim($parsed_url[ 'path' ], '/');
        }
        $parsed_url[ 'path' ] = ltrim(ltrim($base_path, '/') . '/' . $parsed_url[ 'path' ], '/');`

## replace the code with this
`$parsed_url[ 'path' ] = $locale . '/' . ltrim(ltrim($base_path, '/') . '/' . $parsed_url[ 'path' ], '/');`

_** Soory for my bad english **_