### PR TITLE
Fix route translation for Laravel 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "laravel/framework": "~5.2"
+        "laravel/framework": "5.4.*"
     },
     "require-dev": {
-        "orchestra/testbench": "3.2.*"
+        "orchestra/testbench-browser-kit": "~3.4"
     },
     "autoload": {
         "classmap": [

--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -324,7 +324,7 @@ class LaravelLocalization
             $route = '/'.$locale;
         }
         if (is_string($locale) && $this->translator->has($transKeyName, $locale)) {
-            $translation = $this->translator->trans($transKeyName, [], '', $locale);
+            $translation = $this->translator->trans($transKeyName, [], $locale);
             $route .= '/'.$translation;
 
             $route = $this->substituteAttributesInRoute($attributes, $route);
@@ -611,7 +611,7 @@ class LaravelLocalization
     {
         // check if this url is a translated url
         foreach ($this->translatedRoutes as $translatedRoute) {
-            if ($this->translator->trans($translatedRoute, [], '', $url_locale) == rawurldecode($path)) {
+            if ($this->translator->trans($translatedRoute, [], $url_locale) == rawurldecode($path)) {
                 return $translatedRoute;
             }
         }

--- a/tests/LocalizerTests.php
+++ b/tests/LocalizerTests.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Routing\Route;
 
-class LocalizerTests extends \Orchestra\Testbench\TestCase
+class LocalizerTests extends \Orchestra\Testbench\BrowserKit\TestCase
 {
     protected $test_url = 'http://localhost/';
     protected $test_url2 = 'http://localhost';


### PR DESCRIPTION
In Laravel 5.4 the `trans` method of the `Translator` [class](https://laravel.com/api/5.4/Illuminate/Translation/Translator.html#method_trans) accepts 3 arguments instead of 4, therefore the `getURLFromRouteNameTranslated` method of the package is no longer able to translate current routes.

Also pre L5.4 tests require the `testbench-browser-kit` package, as stated in the [upgrade guide](https://laravel.com/docs/5.4/upgrade).