### PR TITLE
Added support for custom order

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,23 @@ It returns a route, localized to the desired locale using the locale passed. If 
 
 This function will return all supported locales and their properties as an array.
 
+### Get Supported Locales Custom Order
+
+```php
+    /**
+     * Return an array of all supported Locales but in the order the user
+     * has specified in the config file. Useful for the language selector.
+     *
+     * @return array
+     */
+     public function getLocalesOrder()
+
+	//Should be called like this:
+	{{ LaravelLocalization::getLocalesOrder() }}
+```
+
+This function will return all supported locales but in the order specified in the configuration file. You can use this function to print locales in the language selector.
+
 ### Get Supported Locales Keys
 
 ```php

--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -386,6 +386,27 @@ class LaravelLocalization
     }
 
     /**
+     * Return an array of all supported Locales but in the order the user
+     * has specified in the config file. Useful for the language selector.
+     *
+     * @return array
+     */
+    public function getLocalesOrder()
+    {
+        $locales = $this->getSupportedLocales();
+
+        $order = $this->configRepository->get('laravellocalization.localesOrder');
+
+        uksort($locales, function ($a, $b) use ($order) {
+            $pos_a = array_search($a, $order);
+            $pos_b = array_search($b, $order);
+            return $pos_a - $pos_b;
+        });
+
+        return $locales;
+    }
+
+    /**
      * Returns current locale name.
      *
      * @return string current locale name
@@ -423,9 +444,9 @@ class LaravelLocalization
             case 'Mong':
             case 'Tfng':
             case 'Thaa':
-                return 'rtl';
+            return 'rtl';
             default:
-                return 'ltr';
+            return 'ltr';
         }
     }
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -309,4 +309,9 @@ return [
     //
     'hideDefaultLocaleInURL' => false,
 
+    // If you want to display the locales in particular order in the language selector you should write the order here. 
+    //CAUTION: Please consider using the appropriate locale code otherwise it will not work
+    //Example: 'localesOrder' => ['es','en'],
+    'localesOrder' => [],
+
 ];


### PR DESCRIPTION
Added another field in the configuration file so the language order can be specified.

Basically we define the order we want in the 'localesOrder' field.
Example `'localesOrder' => ['es','en']`

Then in the blade file we output the language selector we call 
```
<ul class="language_bar_chooser">
  @foreach(LaravelLocalization::getLocalesOrder() as $localeCode => $properties)
    <li>
      <a rel="alternate" hreflang="{{$localeCode}}" href="{{LaravelLocalization::getLocalizedURL($localeCode) }}">
        {{ $properties['native'] }}
      </a>
    </li>
  @endforeach
</ul>
```
and then the languages will have the order we specified. Don't forget to run `php artisan config:cache` after a config change