### PR TITLE
Tweak PHP Composer settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ php:
 
 before_script:
   - composer self-update
-  - composer install --prefer-source --no-interaction --dev
+  - composer install --prefer-dist --no-interaction
 
 script: phpunit -d memory_limit=1024M
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
     "keywords": ["localization", "laravel", "php"],
     "homepage": "https://github.com/mcamara/laravel-localization",
     "license": "MIT",
-    "version": "1.2.3",
     "authors": [
         {
             "name": "Marc Cámara",
@@ -27,5 +26,6 @@
             "Mcamara\\LaravelLocalization": "src/"
         }
     },
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
Remove the version hint as suggested in
https://getcomposer.org/doc/04-schema.md#version
Any version or revision should be determined by a tag, branch or commit SHA.

TravisCI:
Remove --dev flag as it's no longer honored.
Prefer dist over original sources for deps on Travis (performance).