### PR TITLE
[#293] Cant switch to default language if hiding default locale in URL

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -234,7 +234,7 @@ class LaravelLocalization
 
         if (empty($url)) {
             if (!empty($this->routeName)) {
-                return $this->getURLFromRouteNameTranslated($locale, $this->routeName, $attributes);
+                return $this->getURLFromRouteNameTranslated($locale, $this->routeName, $attributes, $forceDefaultLocation);
             }
 
             $url = $this->request->fullUrl();
@@ -243,7 +243,7 @@ class LaravelLocalization
         }
 
         if ($locale && $translatedRoute = $this->findTranslatedRouteByUrl($url, $attributes, $this->currentLocale)) {
-            return $this->getURLFromRouteNameTranslated($locale, $translatedRoute, $attributes);
+            return $this->getURLFromRouteNameTranslated($locale, $translatedRoute, $attributes, $forceDefaultLocation);
         }
 
         $base_path = $this->request->getBaseUrl();
@@ -273,7 +273,7 @@ class LaravelLocalization
         $parsed_url['path'] = ltrim($parsed_url['path'], '/');
 
         if ($translatedRoute = $this->findTranslatedRouteByPath($parsed_url['path'], $url_locale)) {
-            return $this->getURLFromRouteNameTranslated($locale, $translatedRoute, $attributes);
+            return $this->getURLFromRouteNameTranslated($locale, $translatedRoute, $attributes, $forceDefaultLocation);
         }
 
 	if (!empty($locale)) {
@@ -305,13 +305,14 @@ class LaravelLocalization
      * @param string|bool $locale       Locale to adapt
      * @param string      $transKeyName Translation key name of the url to adapt
      * @param array       $attributes   Attributes for the route (only needed if transKeyName needs them)
+     * @param bool        $forceDefaultLocation Force to show default location even hideDefaultLocaleInURL set as TRUE
      *
      * @throws SupportedLocalesNotDefined
      * @throws UnsupportedLocaleException
      *
      * @return string|false URL translated
      */
-    public function getURLFromRouteNameTranslated($locale, $transKeyName, $attributes = [])
+    public function getURLFromRouteNameTranslated($locale, $transKeyName, $attributes = [], $forceDefaultLocation = false)
     {
         if (!$this->checkLocaleInSupportedLocales($locale)) {
             throw new UnsupportedLocaleException('Locale \''.$locale.'\' is not in the list of supported locales.');
@@ -323,7 +324,7 @@ class LaravelLocalization
 
         $route = '';
 
-        if (!($locale === $this->defaultLocale && $this->hideDefaultLocaleInURL())) {
+        if ($forceDefaultLocation || !($locale === $this->defaultLocale && $this->hideDefaultLocaleInURL())) {
             $route = '/'.$locale;
         }
         if (is_string($locale) && $this->translator->has($transKeyName, $locale)) {

--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -211,13 +211,14 @@ class LaravelLocalization
      * @param string|bool  $locale     Locale to adapt, false to remove locale
      * @param string|false $url        URL to adapt in the current language. If not passed, the current url would be taken.
      * @param array        $attributes Attributes to add to the route, if empty, the system would try to extract them from the url.
+     * @param bool         $forceDefaultLocation Force to show default location even hideDefaultLocaleInURL set as TRUE	
      *
      * @throws SupportedLocalesNotDefined
      * @throws UnsupportedLocaleException
      *
      * @return string|false URL translated, False if url does not exist
      */
-    public function getLocalizedURL($locale = null, $url = null, $attributes = [])
+    public function getLocalizedURL($locale = null, $url = null, $attributes = [], $forceDefaultLocation = false)
     {
         if ($locale === null) {
             $locale = $this->getCurrentLocale();
@@ -275,8 +276,10 @@ class LaravelLocalization
             return $this->getURLFromRouteNameTranslated($locale, $translatedRoute, $attributes);
         }
 
-        if (!empty($locale) && ($locale != $this->defaultLocale || !$this->hideDefaultLocaleInURL())) {
-            $parsed_url['path'] = $locale.'/'.ltrim($parsed_url['path'], '/');
+	if (!empty($locale)) {
+            if ($locale != $this->getDefaultLocale() || !$this->hideDefaultLocaleInURL() || $forceDefaultLocation) {
+                $parsed_url['path'] = $locale.'/'.ltrim($parsed_url['path'], '/');
+            }
         }
         $parsed_url['path'] = ltrim(ltrim($base_path, '/').'/'.$parsed_url['path'], '/');
 

--- a/tests/LocalizerTests.php
+++ b/tests/LocalizerTests.php
@@ -189,51 +189,12 @@ class LocalizerTests extends \Orchestra\Testbench\BrowserKit\TestCase
     public function testGetLocalizedURL()
     {
         $this->assertEquals(
-            $this->test_url.'es/acerca',
-            app('laravellocalization')->getLocalizedURL('es', $this->test_url.'en/about')
-        );
-
-        $this->assertEquals(
-            $this->test_url.'es/ver/1',
-            app('laravellocalization')->getLocalizedURL('es', $this->test_url.'view/1')
-        );
-
-        $this->assertEquals(
-            $this->test_url.'es/ver/1/proyecto',
-            app('laravellocalization')->getLocalizedURL('es', $this->test_url.'view/1/project')
-        );
-
-        $this->assertEquals(
-            $this->test_url.'es/ver/1/proyecto/1',
-            app('laravellocalization')->getLocalizedURL('es', $this->test_url.'view/1/project/1')
-        );
-
-        $this->assertEquals(
-            $this->test_url.'en/about',
-            app('laravellocalization')->getLocalizedURL('en', $this->test_url.'about')
-        );
-
-        $this->assertEquals(
             $this->test_url.app('laravellocalization')->getCurrentLocale(),
             app('laravellocalization')->getLocalizedURL()
         );
 
         app('config')->set('laravellocalization.hideDefaultLocaleInURL', true);
         // testing default language hidden
-
-        $this->assertEquals(
-            $this->test_url.'es/acerca',
-            app('laravellocalization')->getLocalizedURL('es', $this->test_url.'about')
-        );
-        $this->assertEquals(
-            $this->test_url.'about',
-            app('laravellocalization')->getLocalizedURL('en', $this->test_url.'about')
-        );
-
-        $this->assertEquals(
-            $this->test_url,
-            app('laravellocalization')->getLocalizedURL()
-        );
 
         $this->assertNotEquals(
             $this->test_url.app('laravellocalization')->getDefaultLocale(),
@@ -309,6 +270,90 @@ class LocalizerTests extends \Orchestra\Testbench\BrowserKit\TestCase
             $this->test_url.'es/test',
             app('laravellocalization')->getLocalizedURL('es', $this->test_url.'test')
         );
+    }
+
+    /**
+     * @param bool $hideDefaultLocaleInURL
+     * @param bool $forceDefault
+     * @param string $locale
+     * @param string $path
+     * @param string $expectedURL
+     *
+     * @dataProvider getLocalizedURLDataProvider
+     */
+    public function testGetLocalizedURLFormat($hideDefaultLocaleInURL, $forceDefault, $locale, $path, $expectedURL)
+    {
+        app('config')->set('laravellocalization.hideDefaultLocaleInURL', $hideDefaultLocaleInURL);
+        $this->assertEquals(
+            $expectedURL,
+            app('laravellocalization')->getLocalizedURL($locale, $path, [], $forceDefault)
+        );
+
+    }
+
+    public function getLocalizedURLDataProvider()
+    {
+        return [
+            // Do not hide default
+            [false, false, 'es', $this->test_url,                       $this->test_url.'es'],
+            [false, false, 'es', $this->test_url.'es',                  $this->test_url.'es'],
+            [false, false, 'es', $this->test_url.'en/about',            $this->test_url.'es/acerca'],
+            [false, false, 'es', $this->test_url.'ver/1',               $this->test_url.'es/ver/1'],
+            [false, false, 'es', $this->test_url.'view/1/project',      $this->test_url.'es/ver/1/proyecto'],
+            [false, false, 'es', $this->test_url.'view/1/project/1',    $this->test_url.'es/ver/1/proyecto/1'],
+
+            // Do not hide default
+            [false, false, 'en', $this->test_url.'en',                  $this->test_url.'en'],
+            [false, false, 'en', $this->test_url.'about',               $this->test_url.'en/about'],
+            [false, false, 'en', $this->test_url.'ver/1',               $this->test_url.'en/ver/1'],
+            [false, false, 'en', $this->test_url.'view/1/project',      $this->test_url.'en/view/1/project'],
+            [false, false, 'en', $this->test_url.'view/1/project/1',    $this->test_url.'en/view/1/project/1'],
+
+            // Hide default
+            [true,  false, 'es', $this->test_url,                       $this->test_url.'es'],
+            [true,  false, 'es', $this->test_url.'es',                  $this->test_url.'es'],
+            [true,  false, 'es', $this->test_url.'en/about',            $this->test_url.'es/acerca'],
+            [true,  false, 'es', $this->test_url.'ver/1',               $this->test_url.'es/ver/1'],
+            [true,  false, 'es', $this->test_url.'view/1/project',      $this->test_url.'es/ver/1/proyecto'],
+            [true,  false, 'es', $this->test_url.'view/1/project/1',    $this->test_url.'es/ver/1/proyecto/1'],
+
+            // Hide default
+            [true,  false, 'en', $this->test_url.'en',                  $this->test_url.''],
+            [true,  false, 'en', $this->test_url.'about',               $this->test_url.'about'],
+            [true,  false, 'en', $this->test_url.'ver/1',               $this->test_url.'ver/1'],
+            [true,  false, 'en', $this->test_url.'view/1/project',      $this->test_url.'view/1/project'],
+            [true,  false, 'en', $this->test_url.'view/1/project/1',    $this->test_url.'view/1/project/1'],
+
+            // Do not hide default FORCE SHOWING
+            [false, true,  'es', $this->test_url,                       $this->test_url.'es'],
+            [false, true,  'es', $this->test_url.'es',                  $this->test_url.'es'],
+            [false, true,  'es', $this->test_url.'en/about',            $this->test_url.'es/acerca'],
+            [false, true,  'es', $this->test_url.'ver/1',               $this->test_url.'es/ver/1'],
+            [false, true,  'es', $this->test_url.'view/1/project',      $this->test_url.'es/ver/1/proyecto'],
+            [false, true,  'es', $this->test_url.'view/1/project/1',    $this->test_url.'es/ver/1/proyecto/1'],
+
+            // Do not hide default FORCE SHOWING
+            [false, true,  'en', $this->test_url.'en',                  $this->test_url.'en'],
+            [false, true,  'en', $this->test_url.'about',               $this->test_url.'en/about'],
+            [false, true,  'en', $this->test_url.'ver/1',               $this->test_url.'en/ver/1'],
+            [false, true,  'en', $this->test_url.'view/1/project',      $this->test_url.'en/view/1/project'],
+            [false, true,  'en', $this->test_url.'view/1/project/1',    $this->test_url.'en/view/1/project/1'],
+
+            // Hide default FORCE SHOWING
+            [true,  true,  'es', $this->test_url,                       $this->test_url.'es'],
+            [true,  true,  'es', $this->test_url.'es',                  $this->test_url.'es'],
+            [true,  true,  'es', $this->test_url.'en/about',            $this->test_url.'es/acerca'],
+            [true,  true,  'es', $this->test_url.'ver/1',               $this->test_url.'es/ver/1'],
+            [true,  true,  'es', $this->test_url.'view/1/project',      $this->test_url.'es/ver/1/proyecto'],
+            [true,  true,  'es', $this->test_url.'view/1/project/1',    $this->test_url.'es/ver/1/proyecto/1'],
+
+            // Hide default FORCE SHOWING
+            [true,  true,  'en', $this->test_url.'en',                  $this->test_url.'en'],
+            [true,  true,  'en', $this->test_url.'about',               $this->test_url.'en/about'],
+            [true,  true,  'en', $this->test_url.'ver/1',               $this->test_url.'en/ver/1'],
+            [true,  true,  'en', $this->test_url.'view/1/project',      $this->test_url.'en/view/1/project'],
+            [true,  true,  'en', $this->test_url.'view/1/project/1',    $this->test_url.'en/view/1/project/1'],
+        ];
     }
 
     public function testGetURLFromRouteNameTranslated()


### PR DESCRIPTION
Related to https://github.com/mcamara/laravel-localization/issues/293

Fo fix the issue e.g. when you need to draw menu to change language but hideDefaultLocaleInURL set to TRUE and you can't switch to this default language.

```
                        <li class="dropdown">
                            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Languahe <span class="caret"></span></a>
                            <ul class="dropdown-menu">
                                @foreach(LaravelLocalization::getSupportedLocales() as $localeCode => $properties)
                                    <li>
                                        <a rel="alternate" hreflang="{{ $localeCode }}" href="{{ LaravelLocalization::getLocalizedURL($localeCode, null, [], true) }}">
                                            {{ $properties['native'] }}
                                        </a>
                                    </li>
                                @endforeach
                            </ul>
                        </li>
```

Here default language will be forced in the URL with `LaravelLocalization::getLocalizedURL($localeCode, null, [], true)`.

So hideDefaultLocaleInURL will change default behavior of whole module, but this parameter allow to change it if needed.
