### PR TITLE
Fix trans params for laravel 5.3

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -328,7 +328,7 @@ class LaravelLocalization
             $route = '/'.$locale;
         }
         if (is_string($locale) && $this->translator->has($transKeyName, $locale)) {
-            $translation = $this->translator->trans($transKeyName, [], $locale);
+            $translation = $this->translator->trans($transKeyName, [], null, $locale);
             $route .= '/'.$translation;
 
             $route = $this->substituteAttributesInRoute($attributes, $route);
@@ -636,7 +636,7 @@ class LaravelLocalization
     {
         // check if this url is a translated url
         foreach ($this->translatedRoutes as $translatedRoute) {
-            if ($this->translator->trans($translatedRoute, [], $url_locale) == rawurldecode($path)) {
+            if ($this->translator->trans($translatedRoute, [], null, $url_locale) == rawurldecode($path)) {
                 return $translatedRoute;
             }
         }


### PR DESCRIPTION
The laravel trans function has 4 parameters. In the current state, named url routes will not function properly. This pull request fixes this.