### PR TITLE
Authorize Laravel 5.3 and 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "laravel/framework": "~5.2"
+        "laravel/framework": "~5.2, ~5.3, ~5.4"
     },
     "require-dev": {
         "orchestra/testbench-browser-kit": "~3.4",


### PR DESCRIPTION
Currently configuration fails with Laravel 5.4.*.