### PR TITLE
Exclude current locale from the language selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,9 @@ public function getSupportedLocales()
 
 //Should be called like this:
 {{ LaravelLocalization::getSupportedLocales() }}
+
+// To exclude current locale from returned array
+{{ LaravelLocalization::getSupportedLocales(true) }}
 ```
 
 This function will return all supported locales and their properties as an array.
@@ -384,6 +387,20 @@ If you're supporting multiple locales in your project you will probably want to 
     @endforeach
 </ul>
 ```
+
+If you want to exclude current locale from the list, in the language selector.
+```
+<ul>
+    @foreach(LaravelLocalization::getSupportedLocales(true) as $localeCode => $properties)
+        <li>
+            <a rel="alternate" hreflang="{{ $localeCode }}" href="{{ LaravelLocalization::getLocalizedURL($localeCode, null, [], true) }}">
+                {{ $properties['native'] }}
+            </a>
+        </li>
+    @endforeach
+</ul>
+```
+
 Here default language will be forced in getLocalizedURL() to be present in the URL even `hideDefaultLocaleInURL = true`.
 
 ## Translated Routes

--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -368,6 +368,7 @@ class LaravelLocalization
     /**
      * Return an array of all supported Locales.
      *
+     * @param boolean $excludeCurrent
      * @throws SupportedLocalesNotDefined
      *
      * @return array

--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -372,21 +372,21 @@ class LaravelLocalization
      *
      * @return array
      */
-    public function getSupportedLocales()
+    public function getSupportedLocales($excludeCurrent = false)
     {
-        if (!empty($this->supportedLocales)) {
-            return $this->supportedLocales;
+        if (empty($this->supportedLocales)) {
+            $this->supportedLocales = $this->configRepository->get('laravellocalization.supportedLocales');
         }
 
-        $locales = $this->configRepository->get('laravellocalization.supportedLocales');
-
-        if (empty($locales) || !is_array($locales)) {
+        if (empty($this->supportedLocales) || !is_array($this->supportedLocales)) {
             throw new SupportedLocalesNotDefined();
         }
 
-        $this->supportedLocales = $locales;
+        if ($excludeCurrent) {
+            unset($this->supportedLocales[$this->currentLocale]);
+        }
 
-        return $locales;
+        return $this->supportedLocales;
     }
 
     /**

--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -383,7 +383,10 @@ class LaravelLocalization
         }
 
         if ($excludeCurrent) {
-            unset($this->supportedLocales[$this->currentLocale]);
+            $locales = $this->supportedLocales;
+            unset($locales[$this->currentLocale]);
+            
+            return $locales;
         }
 
         return $this->supportedLocales;

--- a/tests/LocalizerTests.php
+++ b/tests/LocalizerTests.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Routing\Route;
+use Mcamara\LaravelLocalization\Facades\LaravelLocalization;
 
 class LocalizerTests extends \Orchestra\Testbench\BrowserKit\TestCase
 {
@@ -455,6 +456,20 @@ class LocalizerTests extends \Orchestra\Testbench\BrowserKit\TestCase
             $this->supportedLocales,
             app('laravellocalization')->getSupportedLocales()
         );
+    }
+
+    public function testGetSupportedLocalesExceptCurrent()
+    {
+        $allLocalesCount = count($this->supportedLocales);
+        $currentLocale = $this->defaultLocale;
+        
+        $this->assertThat(
+            LaravelLocalization::getSupportedLocales(true),
+            $this->logicalNot(
+                $this->arrayHasKey($currentLocale)
+            )
+        );
+        $this->assertCount($allLocalesCount - 1, LaravelLocalization::getSupportedLocales(true));
     }
 
     public function testGetCurrentLocaleName()

--- a/tests/LocalizerTests.php
+++ b/tests/LocalizerTests.php
@@ -470,6 +470,8 @@ class LocalizerTests extends \Orchestra\Testbench\BrowserKit\TestCase
             )
         );
         $this->assertCount($allLocalesCount - 1, LaravelLocalization::getSupportedLocales(true));
+
+        $this->assertCount($allLocalesCount, LaravelLocalization::getSupportedLocales(false));
     }
 
     public function testGetCurrentLocaleName()


### PR DESCRIPTION
Some users might want to have the list of supported language excluding the one which is selected at the moment.

```
{{ LaravelLocalization::getSupportedLocales(true) }}
```
enables to exclude it via `$excludeCurrent` param.