### PR TITLE
support Laravel 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "laravel/framework": "~5.2||~5.3||~5.4||~5.5"
+        "laravel/framework": "~5.2||~5.3||~5.4||~5.5||~5.6"
     },
     "require-dev": {
         "orchestra/testbench-browser-kit": "~3.4",


### PR DESCRIPTION
Unlocking Laravel 5.6 doesn't seem to break anything.