### PR TITLE
Fix replacing route parameter with correct key with implicit paramet…

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Easy i18n localization for Laravel, an useful tool to combine with Laravel local
 - <a href="#usage">Usage</a>
     - <a href="#middleware">Middleware</a>
 - <a href="#helpers">Helpers</a>
+    - <a href="#route-model-binding">Route Model Binding</a>
 - <a href="#translated-routes">Translated Routes</a>
 - <a href="#config">Config</a>
     - <a href="#config-files">Config files</a>
@@ -193,6 +194,11 @@ public function getLocalizedURL($locale = null, $url = null, $attributes = array
 ```
 
 It returns a URL localized to the desired locale.
+
+##### Route Model Binding
+
+Note that [route model binding]([https://laravel.com/docs/master/routing#route-model-binding]) is taken into account when generating the localized route.
+
 
 ### Get Clean routes
 
@@ -385,6 +391,8 @@ If you're supporting multiple locales in your project you will probably want to 
 </ul>
 ```
 Here default language will be forced in getLocalizedURL() to be present in the URL even `hideDefaultLocaleInURL = true`.
+
+Note that <a href="#route-model-binding">Route Model Binding</a> is supported.
 
 ## Translated Routes
 

--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -3,6 +3,7 @@
 namespace Mcamara\LaravelLocalization;
 
 use Illuminate\Config\Repository;
+use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
@@ -551,6 +552,9 @@ class LaravelLocalization
     protected function substituteAttributesInRoute($attributes, $route)
     {
         foreach ($attributes as $key => $value) {
+            if ($value instanceOf UrlRoutable) {
+                $value = $value->getRouteKey();
+            }
             $route = str_replace('{'.$key.'}', $value, $route);
             $route = str_replace('{'.$key.'?}', $value, $route);
         }


### PR DESCRIPTION
…er bindings.

Inspired by Illuminate\Routing\UrlGenerator::formatParameters()

With this fix, it's possible to have a route like: /en/{model}/edit
and when trying to get the route in another language (for a selector) with a model of ID:1

 LaravelLocalization::getLocalizedURL'fr', null, [], true)

This url will be returned: /fr/1/editer