### PR TITLE
Mapping locales to custom prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,17 @@ Now you can wrap your views in language-based folders like the translation files
 
 `resources/views/en/`, `resources/views/fr`, ...
 
+### Map your own custom lang url segments
+
+If you want to use custom lang url segments like 'uk' instead of 'en-GB', you can use the mapping ```localesMapping```key to allow the LanguageNegotiator to assign the desired locales based on HTTP Accept Language Header. Here is a quick example, how to map HTTP Accept Language Header 'en-GB' to url segment 'uk':
+
+```php
+// config/laravellocalization.php
+
+'localesMapping' => [
+	'en-GB' => 'uk'
+],
+```
 
 ## Helpers
 

--- a/src/Mcamara/LaravelLocalization/LanguageNegotiator.php
+++ b/src/Mcamara/LaravelLocalization/LanguageNegotiator.php
@@ -2,11 +2,28 @@
 
 namespace Mcamara\LaravelLocalization;
 
+use Illuminate\Config\Repository;
+use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
 use Locale;
 
 class LanguageNegotiator
 {
+
+    /**
+     * Config repository.
+     *
+     * @var \Illuminate\Config\Repository
+     */
+    protected $configRepository;
+
+    /**
+     * Illuminate request class.
+     *
+     * @var Illuminate\Foundation\Application
+     */
+    protected $app;
+
     /**
      * @var string
      */
@@ -34,6 +51,10 @@ class LanguageNegotiator
      */
     public function __construct($defaultLocale, $supportedLanguages, Request $request)
     {
+        $this->app = app();
+
+        $this->configRepository = $this->app['config'];
+
         $this->defaultLocale = $defaultLocale;
 
         if (class_exists('Locale')) {
@@ -78,6 +99,9 @@ class LanguageNegotiator
     {
         $matches = $this->getMatchesFromAcceptedLanguages();
         foreach ($matches as $key => $q) {
+
+            $key = ($this->configRepository->get('laravellocalization.localesMapping')[$key]) ?? $key;
+
             if (!empty($this->supportedLanguages[$key])) {
                 return $key;
             }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -314,6 +314,7 @@ return [
     //Example: 'localesOrder' => ['es','en'],
     'localesOrder' => [],
 
+    //  If you want to use custom lang url segments like 'at' instead of 'de-AT', you can use the mapping to tallow the LanguageNegotiator to assign the descired locales based on HTTP Accept Language Header. For example you want ot use 'at', so map HTTP Accept Language Header 'de-AT' to 'at' (['de-AT' => 'at']).
     'localesMapping' => []
 
 ];

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -199,7 +199,7 @@ return [
         //'ts'          => ['name' => 'Tsonga',                 'script' => 'Latn', 'native' => 'Xitsonga', 'regional' => 'ts_ZA'],
         //'dje'         => ['name' => 'Zarma',                  'script' => 'Latn', 'native' => 'Zarmaciine', 'regional' => ''],
         //'yo'          => ['name' => 'Yoruba',                 'script' => 'Latn', 'native' => 'Èdè Yorùbá', 'regional' => 'yo_NG'],
-        'de-AT'       => ['name' => 'Austrian German',        'script' => 'Latn', 'native' => 'Österreichisches Deutsch', 'regional' => 'de_AT'],
+        // 'de-AT'       => ['name' => 'Austrian German',        'script' => 'Latn', 'native' => 'Österreichisches Deutsch', 'regional' => 'de_AT'],
         //'is'          => ['name' => 'Icelandic',              'script' => 'Latn', 'native' => 'íslenska', 'regional' => 'is_IS'],
         //'cs'          => ['name' => 'Czech',                  'script' => 'Latn', 'native' => 'čeština', 'regional' => 'cs_CZ'],
         //'bas'         => ['name' => 'Basa',                   'script' => 'Latn', 'native' => 'Ɓàsàa', 'regional' => ''],

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -199,7 +199,7 @@ return [
         //'ts'          => ['name' => 'Tsonga',                 'script' => 'Latn', 'native' => 'Xitsonga', 'regional' => 'ts_ZA'],
         //'dje'         => ['name' => 'Zarma',                  'script' => 'Latn', 'native' => 'Zarmaciine', 'regional' => ''],
         //'yo'          => ['name' => 'Yoruba',                 'script' => 'Latn', 'native' => 'Èdè Yorùbá', 'regional' => 'yo_NG'],
-        //'de-AT'       => ['name' => 'Austrian German',        'script' => 'Latn', 'native' => 'Österreichisches Deutsch', 'regional' => 'de_AT'],
+        'de-AT'       => ['name' => 'Austrian German',        'script' => 'Latn', 'native' => 'Österreichisches Deutsch', 'regional' => 'de_AT'],
         //'is'          => ['name' => 'Icelandic',              'script' => 'Latn', 'native' => 'íslenska', 'regional' => 'is_IS'],
         //'cs'          => ['name' => 'Czech',                  'script' => 'Latn', 'native' => 'čeština', 'regional' => 'cs_CZ'],
         //'bas'         => ['name' => 'Basa',                   'script' => 'Latn', 'native' => 'Ɓàsàa', 'regional' => ''],
@@ -309,9 +309,11 @@ return [
     //
     'hideDefaultLocaleInURL' => false,
 
-    // If you want to display the locales in particular order in the language selector you should write the order here. 
+    // If you want to display the locales in particular order in the language selector you should write the order here.
     //CAUTION: Please consider using the appropriate locale code otherwise it will not work
     //Example: 'localesOrder' => ['es','en'],
     'localesOrder' => [],
+
+    'localesMapping' => []
 
 ];


### PR DESCRIPTION
Hi there,

this is my first pull request ever, so there may be mistakes and errors in the workflow, which I would kindly ask you to tell me about in order to fix that.

Here is my goal:

On a client project I have been asked to introduce custom lang prefixes in the supported locales like "uk" instead of "en-GB". So I changed the corresponding key in the config/laravellocalization.php, but of course this led to issues as the automatic language negotiator based on the browser language couldn't match it.

So I enhanced the config/laravellocalizaton.php and added some custom localesMapping array, in which you could specify the desired mapping like this:

`
    'localesMapping' => [
        'en-GB' => 'uk',
        'de-AT' => 'at',
    ]
`

To use this mapping I changed the LanguageNegotiator class and added a call to the configRepository to get this mapping right before resolving the key within the negotiateLanguage() function like that:

`
$key = ($this->configRepository->get('laravellocalization.localesMapping')[$key]) ?? $key;
`

Would be kind to review this and drop me a comment if or if not it is valid and usable.

Cheers and thanks for your hard work on this powerful package,

Chris
