### PR TITLE
remove UTF-8 suffix from regional

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ To set the current locale as view-base-path, simply register the localeViewPath-
 
 Now you can wrap your views in language-based folders like the translation files.
 
-`resources/views/en/`, `resources/vies/fr`, ...
+`resources/views/en/`, `resources/views/fr`, ...
 
 
 ## Helpers

--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -173,8 +173,8 @@ class LaravelLocalization
         // Regional locale such as de_DE, so formatLocalized works in Carbon
         $regional = $this->getCurrentLocaleRegional();
         if ($regional) {
-            setlocale(LC_TIME, $regional.'.UTF-8');
-            setlocale(LC_MONETARY, $regional.'.UTF-8');
+            setlocale(LC_TIME, $regional);
+            setlocale(LC_MONETARY, $regional);
         }
 
         return $locale;

--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -172,9 +172,10 @@ class LaravelLocalization
 
         // Regional locale such as de_DE, so formatLocalized works in Carbon
         $regional = $this->getCurrentLocaleRegional();
+	$suffix = $this->configRepository->get('laravellocalization.utf8suffix');
         if ($regional) {
-            setlocale(LC_TIME, $regional);
-            setlocale(LC_MONETARY, $regional);
+            setlocale(LC_TIME, $regional . $suffix);
+            setlocale(LC_MONETARY, $regional . $suffix);
         }
 
         return $locale;

--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -172,7 +172,7 @@ class LaravelLocalization
 
         // Regional locale such as de_DE, so formatLocalized works in Carbon
         $regional = $this->getCurrentLocaleRegional();
-	$suffix = $this->configRepository->get('laravellocalization.utf8suffix');
+        $suffix = $this->configRepository->get('laravellocalization.utf8suffix');
         if ($regional) {
             setlocale(LC_TIME, $regional . $suffix);
             setlocale(LC_MONETARY, $regional . $suffix);


### PR DESCRIPTION
@mcamara, @lotestudio this update is server configuration specific:
- some linux installations suffix locales with ".UTF-8", some with ".utf8"
- on Windows there is no suffix

I'd propose to remove the forced suffix from setLocale and put suggestion in docs that this need's to be set on a development env in config file.

Optionally a setting 'utf8suffix' => env('LARAVELLOCALIZATION_UTF8SUFFIX', '.UTF-8') could be introduced in config file in order to be able to set this per local environment.