### PR TITLE
Merge in logic of czim/laravel-localization-route-cache

### DIFF
--- a/CACHING.md
+++ b/CACHING.md
@@ -1,0 +1,55 @@
+# Laravel Localization: Caching Routes
+
+If you want to cache the routes in all languages, you will need to use special Artisan commands. **Using `artisan route:cache`** will not work correctly!
+
+## Setup
+
+For the route caching solution to work, it is required to make a minor adjustment to your application route provision.
+
+In your App's `RouteServiceProvider`, use the `LoadsTranslatedCachedRoutes` trait:
+
+```php
+<?php
+class RouteServiceProvider extends ServiceProvider
+{
+    use \Mcamara\LaravelLocalization\Traits\LoadsTranslatedCachedRoutes;
+```
+
+
+## Usage
+
+To cache your routes, use:
+
+``` bash
+php artisan route:trans:cache
+```
+
+... instead of the normal `route:cache` command.
+
+To list the routes for a given locale, use 
+
+``` bash
+php artisan route:trans:list {locale}
+
+# for instance:
+php artisan route:trans:list en
+```
+
+To clear cached routes for all locales, use
+
+``` bash
+php artisan route:trans:clear
+```
+
+### Note
+
+Using `route:clear` will also effectively unset the cache (at the minor cost of leaving some clutter in your bootstrap/cache directory).
+
+
+## History
+
+Caching routes, before version 1.3, was done using a separate package, 
+ [https://github.com/czim/laravel-localization-route-cache](https://github.com/czim/laravel-localization-route-cache).
+ That separate package is no longer required, and should be removed when upgrading to 1.3 or newer. 
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Unreleased (1.3)
+- Merged in solution for caching translated and localized routes (originally in separate package [czim/laravel-localization-route-cache](https://github.com/czim/laravel-localization-route-cache)) by [CZim](https://github.com/czim).  
+    If you used this package, be sure to remove it when upgrading to this version.
+
 ### 1.2.3
 - Added `getLocalesOrder()` function to the package
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### Unreleased (1.3)
+### Unreleased (1.3.11)
 - Merged in solution for caching translated and localized routes (originally in separate package [czim/laravel-localization-route-cache](https://github.com/czim/laravel-localization-route-cache)) by [CZim](https://github.com/czim).  
     If you used this package, be sure to remove it when upgrading to this version.
 

--- a/README.md
+++ b/README.md
@@ -530,9 +530,12 @@ You can create your own config providers and add them on your application config
 
 ## Caching routes
 
-If you want to cache the routes in all languages, please refer to this package: [https://github.com/czim/laravel-localization-route-cache](https://github.com/czim/laravel-localization-route-cache)
+More information on support on [cached (translated) routes here](CACHING.md).
+
+Note that the separate [czim/laravel-localization-route-cache](https://github.com/czim/laravel-localization-route-cache) package is no longer required.
 
 ## Changelog
+
 View changelog here -> [changelog](CHANGELOG.md)
 
 ## License

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,4 +15,10 @@
             <directory suffix=".php">./tests/</directory>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src/Mcamara</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/Mcamara/LaravelLocalization/Commands/RouteTranslationsCacheCommand.php
+++ b/src/Mcamara/LaravelLocalization/Commands/RouteTranslationsCacheCommand.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Mcamara\LaravelLocalization\Commands;
+
+use Mcamara\LaravelLocalization\LaravelLocalization;
+use Mcamara\LaravelLocalization\Traits\TranslatedRouteCommandContext;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Routing\RouteCollection;
+
+class RouteTranslationsCacheCommand extends Command
+{
+    use TranslatedRouteCommandContext;
+
+    /**
+     * @var string
+     */
+    protected $name = 'route:trans:cache';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Create a route cache file for faster route registration for all locales';
+
+    /**
+     * The filesystem instance.
+     *
+     * @var Filesystem
+     */
+    protected $files;
+
+    /**
+     * Create a new route command instance.
+     *
+     * @param Filesystem  $files
+     */
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+
+        $this->files = $files;
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $this->call('route:trans:clear');
+
+        $this->cacheRoutesPerLocale();
+
+        $this->info('Routes cached successfully for all locales!');
+    }
+
+    /**
+     * Cache the routes separately for each locale.
+     */
+    protected function cacheRoutesPerLocale()
+    {
+        // Store the default routes cache,
+        // this way the Application will detect that routes are cached.
+        $allLocales = $this->getSupportedLocales();
+
+        array_push($allLocales, null);
+
+        foreach ($allLocales as $locale) {
+
+            $routes = $this->getFreshApplicationRoutes($locale);
+
+            if (count($routes) == 0) {
+                $this->error("Your application doesn't have any routes.");
+                return;
+            }
+
+            foreach ($routes as $route) {
+                $route->prepareForSerialization();
+            }
+
+            $this->files->put(
+                $this->makeLocaleRoutesPath($locale), $this->buildRouteCacheFile($routes)
+            );
+        }
+    }
+
+    /**
+     * Boot a fresh copy of the application and get the routes.
+     *
+     * @param string|null $locale
+     * @return \Illuminate\Routing\RouteCollection
+     */
+    protected function getFreshApplicationRoutes($locale = null)
+    {
+        $app = require $this->getBootstrapPath() . '/app.php';
+
+        if (null !== $locale) {
+
+            $key = LaravelLocalization::ENV_ROUTE_KEY;
+
+            putenv("{$key}={$locale}");
+
+            $app->make(Kernel::class)->bootstrap();
+
+            putenv("{$key}=");
+
+        } else {
+
+            $app->make(Kernel::class)->bootstrap();
+        }
+
+        return $app['router']->getRoutes();
+    }
+
+    /**
+     * Build the route cache file.
+     *
+     * @param  \Illuminate\Routing\RouteCollection $routes
+     * @return string
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    protected function buildRouteCacheFile(RouteCollection $routes)
+    {
+        $stub = $this->files->get(
+            realpath(
+                __DIR__
+                . DIRECTORY_SEPARATOR . '..'
+                . DIRECTORY_SEPARATOR . '..'
+                . DIRECTORY_SEPARATOR . '..'
+                . DIRECTORY_SEPARATOR . 'stubs'
+                . DIRECTORY_SEPARATOR . 'routes.stub'
+            )
+        );
+
+        return str_replace(
+            [
+                '{{routes}}',
+                '{{translatedRoutes}}',
+            ],
+            [
+                base64_encode(serialize($routes)),
+                $this->getLaravelLocalization()->getSerializedTranslatedRoutes(),
+            ],
+            $stub
+        );
+    }
+}

--- a/src/Mcamara/LaravelLocalization/Commands/RouteTranslationsClearCommand.php
+++ b/src/Mcamara/LaravelLocalization/Commands/RouteTranslationsClearCommand.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Mcamara\LaravelLocalization\Commands;
+
+use Mcamara\LaravelLocalization\Traits\TranslatedRouteCommandContext;
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+
+class RouteTranslationsClearCommand extends Command
+{
+    use TranslatedRouteCommandContext;
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'route:trans:clear';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Remove the translated route cache files for each locale';
+
+    /**
+     * The filesystem instance.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $files;
+
+    /**
+     * Create a new route clear command instance.
+     *
+     * @param  \Illuminate\Filesystem\Filesystem  $files
+     */
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+
+        $this->files = $files;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        foreach ($this->getSupportedLocales() as $locale) {
+
+            $path = $this->makeLocaleRoutesPath($locale);
+
+            if ($this->files->exists($path)) {
+                $this->files->delete($path);
+            }
+        }
+
+        $path = $this->laravel->getCachedRoutesPath();
+
+        if ($this->files->exists($path)) {
+            $this->files->delete($path);
+        }
+
+        $this->info('Route caches for locales cleared!');
+    }
+}

--- a/src/Mcamara/LaravelLocalization/Commands/RouteTranslationsListCommand.php
+++ b/src/Mcamara/LaravelLocalization/Commands/RouteTranslationsListCommand.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Mcamara\LaravelLocalization\Commands;
+
+use Mcamara\LaravelLocalization\LaravelLocalization;
+use Mcamara\LaravelLocalization\Traits\TranslatedRouteCommandContext;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Console\RouteListCommand;
+use Symfony\Component\Console\Input\InputArgument;
+
+class RouteTranslationsListCommand extends RouteListCommand
+{
+    use TranslatedRouteCommandContext;
+
+    /**
+     * @var string
+     */
+    protected $name = 'route:trans:list';
+
+    /**
+     * @var string
+     */
+    protected $description = 'List all registered routes for specific locales';
+
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        if (count($this->routes) == 0) {
+            $this->error("Your application doesn't have any routes.");
+            return;
+        }
+
+        $locale = $this->argument('locale');
+
+        if ( ! $this->isSupportedLocale($locale)) {
+            $this->error("Unsupported locale: '{$locale}'.");
+            return;
+        }
+
+        $this->routes = $this->getFreshApplicationRoutes($locale);
+
+        $this->displayRoutes($this->getRoutes());
+    }
+
+    /**
+     * Boot a fresh copy of the application and get the routes.
+     *
+     * @param string $locale
+     * @return \Illuminate\Routing\RouteCollection
+     */
+    protected function getFreshApplicationRoutes($locale)
+    {
+        $app = require $this->getBootstrapPath() . '/app.php';
+
+        $key = LaravelLocalization::ENV_ROUTE_KEY;
+
+        putenv("{$key}={$locale}");
+
+        $app->make(Kernel::class)->bootstrap();
+
+        putenv("{$key}=");
+
+        return $app['router']->getRoutes();
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [
+            ['locale', InputArgument::REQUIRED, 'The locale to list routes for.'],
+        ];
+    }
+}

--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -10,6 +10,11 @@ use Mcamara\LaravelLocalization\Exceptions\UnsupportedLocaleException;
 class LaravelLocalization
 {
     /**
+     * The env key that the forced locale for routing is stored in.
+     */
+    const ENV_ROUTE_KEY = 'ROUTING_LOCALE';
+
+    /**
      * Config repository.
      *
      * @var \Illuminate\Config\Repository
@@ -138,6 +143,12 @@ class LaravelLocalization
             // If the locale has not been passed through the function
             // it tries to get it from the first segment of the url
             $locale = $this->request->segment(1);
+
+            // If the locale is determined by env, use that
+            // Note that this is how per-locale route caching is performed.
+            if ( ! $locale) {
+                $locale = $this->getForcedLocale();
+            }
         }
 
         if (!empty($this->supportedLocales[$locale])) {
@@ -747,6 +758,31 @@ class LaravelLocalization
     }
 
     /**
+     * Returns serialized translated routes for caching purposes.
+     *
+     * @return string
+     */
+    public function getSerializedTranslatedRoutes()
+    {
+        return base64_encode(serialize($this->translatedRoutes));
+    }
+
+    /**
+     * Sets the translated routes list.
+     * Only useful from a cached routes context.
+     *
+     * @param string $serializedRoutes
+     */
+    public function setSerializedTranslatedRoutes($serializedRoutes)
+    {
+        if ( ! $serializedRoutes) {
+            return;
+        }
+
+        $this->translatedRoutes = unserialize(base64_decode($serializedRoutes));
+    }
+
+    /**
      * Extract attributes for current url.
      *
      * @param bool|false|null|string $url    to extract attributes, if not present, the system will look for attributes in the current call
@@ -888,4 +924,14 @@ class LaravelLocalization
          }
          return $attributes;
      }
+
+    /**
+     * Returns the forced environment set route locale.
+     *
+     * @return string|null
+     */
+    protected function getForcedLocale()
+    {
+        return env(static::ENV_ROUTE_KEY);
+    }
 }

--- a/src/Mcamara/LaravelLocalization/LaravelLocalizationServiceProvider.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalizationServiceProvider.php
@@ -41,10 +41,36 @@ class LaravelLocalizationServiceProvider extends ServiceProvider
             $packageConfigFile, 'laravellocalization'
         );
 
+        $this->registerBindings();
+
+        $this->registerCommands();
+    }
+
+    /**
+     * Registers app bindings and aliases.
+     */
+    protected function registerBindings()
+    {
         $this->app->singleton(LaravelLocalization::class, function () {
             return new LaravelLocalization();
         });
 
         $this->app->alias(LaravelLocalization::class, 'laravellocalization');
+    }
+
+    /**
+     * Registers route caching commands.
+     */
+    protected function registerCommands()
+    {
+        $this->app->singleton('laravellocalizationroutecache.cache', Commands\RouteTranslationsCacheCommand::class);
+        $this->app->singleton('laravellocalizationroutecache.clear', Commands\RouteTranslationsClearCommand::class);
+        $this->app->singleton('laravellocalizationroutecache.list', Commands\RouteTranslationsListCommand::class);
+
+        $this->commands([
+            'laravellocalizationroutecache.cache',
+            'laravellocalizationroutecache.clear',
+            'laravellocalizationroutecache.list',
+        ]);
     }
 }

--- a/src/Mcamara/LaravelLocalization/Traits/LoadsTranslatedCachedRoutes.php
+++ b/src/Mcamara/LaravelLocalization/Traits/LoadsTranslatedCachedRoutes.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Mcamara\LaravelLocalization\Traits;
+
+use Illuminate\Support\Facades\Log;
+
+/**
+ * LoadsTranslatedCachedRoutes
+ *
+ * Add this trait to your App\RouteServiceProvider to load
+ * translated cached routes for the active locale, instead
+ * of the default locale's routes (irrespective of active).
+ */
+trait LoadsTranslatedCachedRoutes
+{
+    /**
+     * Load the cached routes for the application.
+     *
+     * @return void
+     */
+    protected function loadCachedRoutes()
+    {
+        $localization = $this->getLaravelLocalization();
+
+        $localization->setLocale();
+
+        $locale = $localization->getCurrentLocale();
+
+        $localeKeys = $localization->getSupportedLanguagesKeys();
+
+        // First, try to load the routes specifically cached for this locale
+        // if they do not exist, write a warning to the log and load the default
+        // routes instead. Note that this is guaranteed to exist, because the
+        // 'cached routes' check in the Application checks its existence.
+
+        $path = $this->makeLocaleRoutesPath($locale, $localeKeys);
+
+        if ( ! file_exists($path)) {
+
+            Log::warning("Routes cached, but no cached routes found for locale '{$locale}'!");
+
+            $path = $this->getDefaultCachedRoutePath();
+        }
+
+        $this->app->booted(function () use ($path) {
+            require $path;
+        });
+    }
+
+    /**
+     * Returns the path to the cached routes file for a given locale.
+     *
+     * @param string   $locale
+     * @param string[] $localeKeys
+     * @return string
+     */
+    protected function makeLocaleRoutesPath($locale, $localeKeys)
+    {
+        $path = $this->getDefaultCachedRoutePath();
+
+        $localeSegment = request()->segment(1);
+        if ( ! $localeSegment || ! in_array($localeSegment, $localeKeys)) {
+            return $path;
+        }
+
+        return substr($path, 0, -4) . '_' . $locale . '.php';
+    }
+
+    /**
+     * Returns the path to the standard cached routes file.
+     *
+     * @return string
+     */
+    protected function getDefaultCachedRoutePath()
+    {
+        return $this->app->getCachedRoutesPath();
+    }
+
+    /**
+     * @return \Mcamara\LaravelLocalization\LaravelLocalization
+     */
+    protected function getLaravelLocalization()
+    {
+        return app('laravellocalization');
+    }
+}

--- a/src/Mcamara/LaravelLocalization/Traits/TranslatedRouteCommandContext.php
+++ b/src/Mcamara/LaravelLocalization/Traits/TranslatedRouteCommandContext.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Mcamara\LaravelLocalization\Traits;
+
+trait TranslatedRouteCommandContext
+{
+    /**
+     * Returns whether a given locale is supported.
+     *
+     * @param string $locale
+     * @return bool
+     */
+    protected function isSupportedLocale($locale)
+    {
+        return in_array($locale, $this->getSupportedLocales());
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getSupportedLocales()
+    {
+        return $this->getLaravelLocalization()->getSupportedLanguagesKeys();
+    }
+
+    /**
+     * @return \Mcamara\LaravelLocalization\LaravelLocalization
+     */
+    protected function getLaravelLocalization()
+    {
+        return $this->laravel->make('laravellocalization');
+    }
+
+    /**
+     * @return string
+     */
+    protected function getBootstrapPath()
+    {
+        if (method_exists($this->laravel, 'bootstrapPath')) {
+            return $this->laravel->bootstrapPath();
+        }
+
+        return $this->laravel->basePath() . DIRECTORY_SEPARATOR . 'bootstrap';
+    }
+
+    /**
+     * @param string $locale
+     * @return string
+     */
+    protected function makeLocaleRoutesPath($locale = '')
+    {
+        $path = $this->laravel->getCachedRoutesPath();
+
+        if ( ! $locale ) {
+            return $path;
+        }
+
+        return substr($path, 0, -4) . '_' . $locale . '.php';
+    }
+}

--- a/src/stubs/routes.stub
+++ b/src/stubs/routes.stub
@@ -1,0 +1,20 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Load The Translated Cached Routes
+|--------------------------------------------------------------------------
+|
+| Here we will decode and unserialize the RouteCollection instance that
+| holds all of the route information for an application. This allows
+| us to instantaneously load the entire route map into the router.
+|
+| This also preps LaravelLocalization to deal with translated routes.
+|
+*/
+
+app('router')->setRoutes(
+    unserialize(base64_decode('{{routes}}'))
+);
+
+app('laravellocalization')->setSerializedTranslatedRoutes('{{translatedRoutes}}');


### PR DESCRIPTION
Here's my take on what we discussed by email earlier. This merges in only the existing functionality offered by [czim/laravel-localization-route-cache](https://github.com/czim/laravel-localization-route-cache), nothing else.

The changes should be backwards-compatible, and only require changes to the setup for people who already make use of route caching, or the old separate caching package.

I tried to match style and keep things clean. If you want me to tweak the style further, let me know what needs to change and I'll take care of it.

I did not add tests. I think I'd have to set up orchestra testbench as a dev composer dependency and do a whole bunch of work to get those rolling. It'd be worth it, but I wanted to present this first, and check how you feel about tests for this package -- seeing how the package is not 100% covered as-is, I figured they might not be a high priority.

Finally, I updated the readme, added a separate readme file about caching and added a note to the changelog. These are obviously merely suggestions, so let me know what you think.