### PR TITLE
Load skipped URLs from configuration.

### DIFF
--- a/src/Mcamara/LaravelLocalization/Middleware/LaravelLocalizationMiddlewareBase.php
+++ b/src/Mcamara/LaravelLocalization/Middleware/LaravelLocalizationMiddlewareBase.php
@@ -10,7 +10,7 @@ class LaravelLocalizationMiddlewareBase
      *
      * @var array
      */
-    protected $except = [];
+    protected $except;
 
     /**
      * Determine if the request has a URI that should not be localized.
@@ -20,6 +20,7 @@ class LaravelLocalizationMiddlewareBase
      */
     protected function shouldIgnore($request)
     {
+        $this->except = $this->except ?? config('laravellocalization.urlsIgnored', []);
         foreach ($this->except as $except) {
             if ($except !== '/') {
                 $except = trim($except, '/');

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -318,4 +318,7 @@ return [
     // Defaults to most common ".UTF-8". Set to blank on Windows systems, change to ".utf8" on CentOS and similar.
     'utf8suffix' => env('LARAVELLOCALIZATION_UTF8SUFFIX', '.UTF-8'),
 
+    // URLs which should not be processed, e.g. '/nova', '/nova/*', '/nova-api/*' or specific application URLs
+    // Defaults to []
+    'urlsIgnored' => ['/skipped'],
 ];

--- a/tests/LocalizerTests.php
+++ b/tests/LocalizerTests.php
@@ -68,6 +68,10 @@ class LocalizerTests extends \Orchestra\Testbench\BrowserKit\TestCase
                 return app('laravellocalization')->getLocalizedURL('es') ?: 'Not url available';
             }, ]);
         });
+
+        app('router')->get('/skipped', ['as'=> 'skipped', function () {
+            return Request::url();
+        }, ]);
     }
 
     /**
@@ -269,6 +273,23 @@ class LocalizerTests extends \Orchestra\Testbench\BrowserKit\TestCase
         $this->assertEquals(
             $this->test_url.'es/test',
             app('laravellocalization')->getLocalizedURL('es', $this->test_url.'test')
+        );
+    }
+
+    public function testGetLocalizedUrlForIgnoredUrls() {
+        $crawler = $this->call(
+            'GET',
+            $this->test_url2.'/skipped',
+            [],
+            [],
+            [],
+            ['HTTP_ACCEPT_LANGUAGE' => 'en,es']
+        );
+
+        $this->assertResponseOk();
+        $this->assertEquals(
+            $this->test_url2.'/skipped',
+            $crawler->getContent()
         );
     }
 

--- a/tests/full-config/config.php
+++ b/tests/full-config/config.php
@@ -314,4 +314,7 @@ return [
     //Example: 'localesOrder' => ['es','en'],
     'localesOrder' => [],
 
+    // URLs which should not be processed, e.g. '/nova', '/nova/*', '/nova-api/*' or specific application URLs
+    // Defaults to []
+    'urlsIgnored' => [],
 ];


### PR DESCRIPTION
This PR adds a new configuration setting `urlsIgnored`, where developer can specify URLs to skip.