### PR TITLE
Remove useless required from composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "laravel/framework": "~5.2"
+        "laravel/framework": "~5.2.0||~5.3.0||~5.4.0||~5.5.0||~5.6.0||~5.7.0"
     },
     "require-dev": {
         "orchestra/testbench-browser-kit": "~3.4",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "laravel/framework": "~5.2||~5.3||~5.4||~5.5||~5.6"
+        "laravel/framework": "~5.2"
     },
     "require-dev": {
         "orchestra/testbench-browser-kit": "~3.4",


### PR DESCRIPTION
this **PR** removes useless **||** requires , as[ composer tilde version range](https://getcomposer.org/doc/articles/versions.md#tilde-version-range-) will work