### PR TITLE
Cleanup code in LaravelLocalizationRedirectFilter

### DIFF
--- a/src/Mcamara/LaravelLocalization/Middleware/LaravelLocalizationRedirectFilter.php
+++ b/src/Mcamara/LaravelLocalization/Middleware/LaravelLocalizationRedirectFilter.php
@@ -5,7 +5,7 @@ namespace Mcamara\LaravelLocalization\Middleware;
 use Closure;
 use Illuminate\Http\RedirectResponse;
 
-class LaravelLocalizationRedirectFilter extends LaravelLocalizationMiddlewareBase 
+class LaravelLocalizationRedirectFilter extends LaravelLocalizationMiddlewareBase
 {
     /**
      * Handle an incoming request.
@@ -22,34 +22,23 @@ class LaravelLocalizationRedirectFilter extends LaravelLocalizationMiddlewareBas
             return $next($request);
         }
 
-        $currentLocale = app('laravellocalization')->getCurrentLocale();
-        $defaultLocale = app('laravellocalization')->getDefaultLocale();
         $params = explode('/', $request->getPathInfo());
+
         // Dump the first element (empty string) as getPathInfo() always returns a leading slash
         array_shift($params);
 
         if (\count($params) > 0) {
             $localeCode = $params[0];
-            $locales = app('laravellocalization')->getSupportedLocales();
-            $hideDefaultLocale = app('laravellocalization')->hideDefaultLocaleInURL();
-            $redirection = false;
 
-            if (!empty($locales[$localeCode])) {
-                if ($localeCode === $defaultLocale && $hideDefaultLocale) {
+            if (app('laravellocalization')->checkLocaleInSupportedLocales($localeCode)) {
+                if ($localeCode === app('laravellocalization')->getDefaultLocale() && app('laravellocalization')->hideDefaultLocaleInURL()) {
                     $redirection = app('laravellocalization')->getNonLocalizedURL();
+
+                    // Save any flashed data for redirect
+                    app('session')->reflash();
+
+                    return new RedirectResponse($redirection, 302, ['Vary' => 'Accept-Language']);
                 }
-            } elseif ($currentLocale !== $defaultLocale || !$hideDefaultLocale) {
-                // If the current url does not contain any locale
-                // The system redirect the user to the very same url "localized"
-                // we use the current locale to redirect him
-                $redirection = app('laravellocalization')->getLocalizedURL(session('locale'), $request->fullUrl());
-            }
-
-            if ($redirection) {
-                // Save any flashed data for redirect
-                app('session')->reflash();
-
-                return new RedirectResponse($redirection, 302, ['Vary' => 'Accept-Language']);
             }
         }
 


### PR DESCRIPTION
The `elseif` is superfluous. Note that
`
($currentLocale !== $defaultLocale || !$hideDefaultLocale)`

is equivalent to

`!(($currentLocale == $defaultLocale && $hideDefaultLocale))`

This means the `elseif` part is only executed if the locale from url is not valid and 
`
!(($currentLocale == $defaultLocale && $hideDefaultLocale))`

but this case has been checked before in `LocaleSessionRedirect`. If the middleware  `LocaleSessionRedirect` is not used, then `session(‘locale’)` is null anyway and `$redirection` remains false. 

Thus its also superfluous to check `if($redirection)` since there is only one case. There is also no need for some variables since they occur now only once. The variable `!empty($locales[$localeCode])` can be replaced by `app('laravellocalization')→checkLocaleInSupportedLocales($localeCode)`. Some variables are not even needed anymore and have been deleted.

All in all, the class is much cleaner now. Nothing changed on the functionality. 