### PR TITLE
Fix https://github.com/mcamara/laravel-localization/issues/305

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ In order to activate it, you just have to attach this middleware to the routes y
 
 If you want to hide the default locale but always show other locales in the url, switch the `hideDefaultLocaleInURL` config value to true. Once it's true, if the default locale is en (english) all URLs containing /en/ would be redirected to the same url without this fragment '/' but maintaining the locale as en (English).
 
-**IMPORTANT** - When `hideDefaultLocaleInURL` is set to true, the unlocalized root is treated as the applications default locale `app.locale`.  Because of this language negotiation using the Accept-Language header will **NEVER** occur when `hideDefaultLocaleInURL` is true.
+When `hideDefaultLocaleInURL` and `useAcceptLanguageHeader` are both set to true,then the language negotiation using the Accept-Language header will only occur while the session('locale') is empty. After negotiation, the session('locale') will be set accordingly and will not be called again.
 
 ### Set current locale as view-base-path
 

--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -729,6 +729,11 @@ class LaravelLocalization
         return $this->configRepository->get('laravellocalization.useAcceptLanguageHeader');
     }
 
+    public function hideUrlAndAcceptHeader()
+    {
+      return $this->hideDefaultLocaleInURL() && $this->useAcceptLanguageHeader();
+    }
+
     /**
      * Returns the translation key for a given path.
      *

--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -187,6 +187,19 @@ class LaravelLocalization
     }
 
     /**
+     * Check if $locale is default locale and supposed to be hidden in url
+     *
+     * @param string $locale Locale to be checked
+     *
+     * @return boolean Returns true if above requirement are met, otherwise false
+     */
+
+     public function isHiddenDefault($locale)
+     {
+       return  ($this->getDefaultLocale() === $locale && $this->hideDefaultLocaleInURL());
+     }
+
+    /**
      * Set and return supported locales.
      *
      * @param array $locales Locales that the App supports

--- a/src/Mcamara/LaravelLocalization/Middleware/LaravelLocalizationRedirectFilter.php
+++ b/src/Mcamara/LaravelLocalization/Middleware/LaravelLocalizationRedirectFilter.php
@@ -5,7 +5,7 @@ namespace Mcamara\LaravelLocalization\Middleware;
 use Closure;
 use Illuminate\Http\RedirectResponse;
 
-class LaravelLocalizationRedirectFilter extends LaravelLocalizationMiddlewareBase 
+class LaravelLocalizationRedirectFilter extends LaravelLocalizationMiddlewareBase
 {
     /**
      * Handle an incoming request.
@@ -22,34 +22,23 @@ class LaravelLocalizationRedirectFilter extends LaravelLocalizationMiddlewareBas
             return $next($request);
         }
 
-        $currentLocale = app('laravellocalization')->getCurrentLocale();
-        $defaultLocale = app('laravellocalization')->getDefaultLocale();
         $params = explode('/', $request->getPathInfo());
+
         // Dump the first element (empty string) as getPathInfo() always returns a leading slash
         array_shift($params);
 
         if (\count($params) > 0) {
             $localeCode = $params[0];
-            $locales = app('laravellocalization')->getSupportedLocales();
-            $hideDefaultLocale = app('laravellocalization')->hideDefaultLocaleInURL();
-            $redirection = false;
 
-            if (!empty($locales[$localeCode])) {
-                if ($localeCode === $defaultLocale && $hideDefaultLocale) {
+            if (app('laravellocalization')->checkLocaleInSupportedLocales($localeCode)) {
+                if ($localeCode === app('laravellocalization')->getDefaultLocale() && app('laravellocalization')->hideDefaultLocaleInURL()) {
                     $redirection = app('laravellocalization')->getNonLocalizedURL();
+
+                    // Save any flashed data for redirect
+                    app('session')->reflash();
+
+                    return new RedirectResponse($redirection, 302, ['Vary' => 'Accept-Language']);
                 }
-            } elseif ($currentLocale !== $defaultLocale || !$hideDefaultLocale) {
-                // If the current url does not contain any locale
-                // The system redirect the user to the very same url "localized"
-                // we use the current locale to redirect him
-                $redirection = app('laravellocalization')->getLocalizedURL(session('locale'), $request->fullUrl());
-            }
-
-            if ($redirection) {
-                // Save any flashed data for redirect
-                app('session')->reflash();
-
-                return new RedirectResponse($redirection, 302, ['Vary' => 'Accept-Language']);
             }
         }
 

--- a/src/Mcamara/LaravelLocalization/Middleware/LaravelLocalizationRedirectFilter.php
+++ b/src/Mcamara/LaravelLocalization/Middleware/LaravelLocalizationRedirectFilter.php
@@ -28,10 +28,10 @@ class LaravelLocalizationRedirectFilter extends LaravelLocalizationMiddlewareBas
         array_shift($params);
 
         if (\count($params) > 0) {
-            $localeCode = $params[0];
+            $locale = $params[0];
 
-            if (app('laravellocalization')->checkLocaleInSupportedLocales($localeCode)) {
-                if ($localeCode === app('laravellocalization')->getDefaultLocale() && app('laravellocalization')->hideDefaultLocaleInURL()) {
+            if (app('laravellocalization')->checkLocaleInSupportedLocales($locale)) {
+                if (app('laravellocalization')->isHiddenDefault($locale)) {
                     $redirection = app('laravellocalization')->getNonLocalizedURL();
 
                     // Save any flashed data for redirect

--- a/src/Mcamara/LaravelLocalization/Middleware/LocaleCookieRedirect.php
+++ b/src/Mcamara/LaravelLocalization/Middleware/LocaleCookieRedirect.php
@@ -3,7 +3,7 @@
 use Closure;
 use Illuminate\Http\RedirectResponse;
 
-class LocaleCookieRedirect extends LaravelLocalizationMiddlewareBase 
+class LocaleCookieRedirect extends LaravelLocalizationMiddlewareBase
 {
 
     /**
@@ -27,7 +27,7 @@ class LocaleCookieRedirect extends LaravelLocalizationMiddlewareBase
             return $next($request)->withCookie(cookie()->forever('locale', $params[0]));
          }
 
-         if ($locale && app('laravellocalization')->checkLocaleInSupportedLocales($locale) && !(app('laravellocalization')->getDefaultLocale() === $locale && app('laravellocalization')->hideDefaultLocaleInURL())) {
+         if ($locale && app('laravellocalization')->checkLocaleInSupportedLocales($locale) && !(app('laravellocalization')->isHiddenDefault($locale))) {
            $redirection = app('laravellocalization')->getLocalizedURL($locale);
            $redirectResponse = new RedirectResponse($redirection, 302, ['Vary' => 'Accept-Language']);
 

--- a/src/Mcamara/LaravelLocalization/Middleware/LocaleSessionRedirect.php
+++ b/src/Mcamara/LaravelLocalization/Middleware/LocaleSessionRedirect.php
@@ -4,6 +4,8 @@ namespace Mcamara\LaravelLocalization\Middleware;
 
 use Closure;
 use Illuminate\Http\RedirectResponse;
+use Mcamara\LaravelLocalization\LanguageNegotiator;
+use Mcamara\LaravelLocalization\LaravelLocalization;
 
 class LocaleSessionRedirect extends LaravelLocalizationMiddlewareBase
 {
@@ -30,14 +32,18 @@ class LocaleSessionRedirect extends LaravelLocalizationMiddlewareBase
 
             return $next($request);
         }
-        elseif(empty($locale) && app('laravellocalization')->hideDefaultLocaleInURL() && app('laravellocalization')->useAcceptLanguageHeader()){
+        elseif(empty($locale) && app('laravellocalization')->hideUrlAndAcceptHeader()){
           // When default locale is hidden and accept language header is true,
           // then compute browser language when no session has been set.
           // Once the session has been set, there is no need
           // to negotiate language from browser again.
-          $negotiator = new LanguageNegotiator(LaravelLocalization::getDefaultLocale(), LaravelLocalization::getSupportedLocales(), $request);
+          $negotiator = new LanguageNegotiator(app('laravellocalization')->getDefaultLocale(), app('laravellocalization')->getSupportedLocales(), $request);
           $locale     = $negotiator->negotiateLanguage();
-          session(['locale' => $locale]);          
+          session(['locale' => $locale]);
+        }
+
+        if($locale === false){
+          $locale = app('laravellocalization')->getCurrentLocale();
         }
 
         if ($locale && app('laravellocalization')->checkLocaleInSupportedLocales($locale) && !(app('laravellocalization')->isHiddenDefault($locale))) {

--- a/src/Mcamara/LaravelLocalization/Middleware/LocaleSessionRedirect.php
+++ b/src/Mcamara/LaravelLocalization/Middleware/LocaleSessionRedirect.php
@@ -30,8 +30,17 @@ class LocaleSessionRedirect extends LaravelLocalizationMiddlewareBase
 
             return $next($request);
         }
+        elseif(empty($locale) && app('laravellocalization')->hideDefaultLocaleInURL() && app('laravellocalization')->useAcceptLanguageHeader()){
+          // When default locale is hidden and accept language header is true,
+          // then compute browser language when no session has been set.
+          // Once the session has been set, there is no need
+          // to negotiate language from browser again.
+          $negotiator = new LanguageNegotiator(LaravelLocalization::getDefaultLocale(), LaravelLocalization::getSupportedLocales(), $request);
+          $locale     = $negotiator->negotiateLanguage();
+          session(['locale' => $locale]);          
+        }
 
-        if ($locale && app('laravellocalization')->checkLocaleInSupportedLocales($locale) && !(app('laravellocalization')->getDefaultLocale() === $locale && app('laravellocalization')->hideDefaultLocaleInURL())) {
+        if ($locale && app('laravellocalization')->checkLocaleInSupportedLocales($locale) && !(app('laravellocalization')->isHiddenDefault($locale))) {
             app('session')->reflash();
             $redirection = app('laravellocalization')->getLocalizedURL($locale);
 


### PR DESCRIPTION
This commits fixes https://github.com/mcamara/laravel-localization/issues/305

If one enables `useAcceptLanguageHeader` and `hideDefaultLocaleInURL` then this works now. If the first request contains no local in the url, the local will be determined by the AcceptLanguageHeader and stored in the session. While the session is active, AcceptLanguageHeader will not be used again. Instead, if the url contains no locale, then default locale will be shown.

Also this commits includes a fix for https://github.com/mcamara/laravel-localization/pull/598 I apologize that I missed one case when testing. When `hideDefaultLocaleInURL` is disabled and one calls a url without locale, then no redirect was happening. This is because I missed in my argumentation in  https://github.com/mcamara/laravel-localization/pull/598 that `app('laravellocalization')->getCurrentLocale();` and `session(..)` are different if session is empty.  

I am sorry about it! Fortunately it could be easily fixed with 

```
    if($locale === false){
          $locale = app('laravellocalization')->getCurrentLocale();
        }
```

in `LocaleSessionRedirect`