### PR TITLE
getLocalizedURL produce duplicate query string

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -262,6 +262,7 @@ class LaravelLocalization
             $url = $this->request->fullUrl();
         } else {
             $url = $this->url->to($url);
+            $url = preg_replace('/'. preg_quote($urlQuery, '/') . '$/', '', $url);
         }
 
         if ($locale && $translatedRoute = $this->findTranslatedRouteByUrl($url, $attributes, $this->currentLocale)) {

--- a/tests/LocalizerTests.php
+++ b/tests/LocalizerTests.php
@@ -257,6 +257,11 @@ class LocalizerTests extends \Orchestra\Testbench\BrowserKit\TestCase
             app('laravellocalization')->getLocalizedURL('en', $this->test_url.'test')
         );
 
+        $this->assertEquals(
+            $this->test_url.'test?a=1',
+            app('laravellocalization')->getLocalizedURL('en', $this->test_url.'test?a=1')
+        );
+
         $crawler = $this->call(
             'GET',
             app('laravellocalization')->getLocalizedURL('en', $this->test_url.'test'),
@@ -277,6 +282,11 @@ class LocalizerTests extends \Orchestra\Testbench\BrowserKit\TestCase
         $this->assertEquals(
             $this->test_url.'es/test',
             app('laravellocalization')->getLocalizedURL('es', $this->test_url.'test')
+        );
+
+        $this->assertEquals(
+            $this->test_url.'es/test?a=1',
+            app('laravellocalization')->getLocalizedURL('es', $this->test_url.'test?a=1')
         );
     }
 


### PR DESCRIPTION
Fixed getLocalizedURL producing duplicate query string (side effect of #578). The test is included.