### PR TITLE
Respect locales mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+### 1.3.20
+- Respect locales mapping ([#631](https://github.com/mcamara/laravel-localization/pull/631))
+
 ### 1.3.11
-- Merged in solution for caching translated and localized routes (originally in separate package [czim/laravel-localization-route-cache](https://github.com/czim/laravel-localization-route-cache)) by [CZim](https://github.com/czim).  
+- Merged in solution for caching translated and localized routes (originally in separate package [czim/laravel-localization-route-cache](https://github.com/czim/laravel-localization-route-cache)) by [CZim](https://github.com/czim).
     If you used this package, be sure to remove it when upgrading to this version.
 - Added `'utf8suffix' => env('LARAVELLOCALIZATION_UTF8SUFFIX', '.UTF-8')` to config file.
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,13 @@ localesMapping``` is needed to enable the LanguageNegotiator to correctly assign
 ],
 ```
 
+After that ```http://url-to-laravel/en-GB/a/b/c``` becomes ```http://url-to-laravel/uk/a/b/c```.
+
+```php
+LaravelLocalization::getLocalizedURL('en-GB', 'a/b/c'); // http://url-to-laravel/uk/a/b/c
+LaravelLocalization::getLocalizedURL('uk', 'a/b/c'); // http://url-to-laravel/uk/a/b/c
+```
+
 ## Helpers
 
 This package comes with some useful functions, like:

--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -295,6 +295,8 @@ class LaravelLocalization
             $parsed_url['path'] = str_replace($base_path, '', '/'.ltrim($parsed_url['path'], '/'));
             $path = $parsed_url['path'];
             foreach ($this->getSupportedLocales() as $localeCode => $lang) {
+                $localeCode = $this->getLocaleFromMapping($localeCode);
+
                 $parsed_url['path'] = preg_replace('%^/?'.$localeCode.'/%', '$1', $parsed_url['path']);
                 if ($parsed_url['path'] !== $path) {
                     $url_locale = $localeCode;

--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -85,6 +85,13 @@ class LaravelLocalization
     protected $supportedLocales;
 
     /**
+     * Locales mapping.
+     *
+     * @var array
+     */
+    protected $localesMapping;
+
+    /**
      * Current locale.
      *
      * @var string
@@ -158,6 +165,8 @@ class LaravelLocalization
             }
         }
 
+        $locale = $this->getInversedLocaleFromMapping($locale);
+
         if (!empty($this->supportedLocales[$locale])) {
             $this->currentLocale = $locale;
         } else {
@@ -190,7 +199,7 @@ class LaravelLocalization
             setlocale(LC_MONETARY, $regional . $suffix);
         }
 
-        return $locale;
+        return $this->getLocaleFromMapping($locale);
     }
 
     /**
@@ -306,7 +315,9 @@ class LaravelLocalization
             return $this->getURLFromRouteNameTranslated($locale, $translatedRoute, $attributes, $forceDefaultLocation).$urlQuery;
         }
 
-	    if (!empty($locale)) {
+        $locale = $this->getLocaleFromMapping($locale);
+
+        if (!empty($locale)) {
             if ($forceDefaultLocation || $locale != $this->getDefaultLocale() || !$this->hideDefaultLocaleInURL()) {
                 $parsed_url['path'] = $locale.'/'.ltrim($parsed_url['path'], '/');
             }
@@ -393,6 +404,44 @@ class LaravelLocalization
     public function getDefaultLocale()
     {
         return $this->defaultLocale;
+    }
+
+    /**
+     * Return locales mapping.
+     *
+     * @return array
+     */
+    public function getLocalesMapping()
+    {
+        if (empty($this->localesMapping)) {
+            $this->localesMapping = $this->configRepository->get('laravellocalization.localesMapping');
+        }
+
+        return $this->localesMapping;
+    }
+
+    /**
+     * Returns a locale from the mapping.
+     *
+     * @param string|null $locale
+     *
+     * @return string|null
+     */
+    public function getLocaleFromMapping($locale)
+    {
+        return $this->getLocalesMapping()[$locale] ?? $locale;
+    }
+
+    /**
+     * Returns inversed locale from the mapping.
+     *
+     * @param string|null $locale
+     *
+     * @return string|null
+     */
+    public function getInversedLocaleFromMapping($locale)
+    {
+        return \array_flip($this->getLocalesMapping())[$locale] ?? $locale;
     }
 
     /**
@@ -562,8 +611,9 @@ class LaravelLocalization
      */
     public function checkLocaleInSupportedLocales($locale)
     {
+        $inversedLocale = $this->getInversedLocaleFromMapping($locale);
         $locales = $this->getSupportedLocales();
-        if ($locale !== false && empty($locales[$locale])) {
+        if ($locale !== false && empty($locales[$locale]) && empty($locales[$inversedLocale])) {
             return false;
         }
 

--- a/tests/LocalizerTests.php
+++ b/tests/LocalizerTests.php
@@ -800,5 +800,6 @@ class LocalizerTests extends \Orchestra\Testbench\BrowserKit\TestCase
 
         $this->assertEquals('http://localhost/custom/some-route', app('laravellocalization')->localizeURL('some-route', 'en'));
         $this->assertEquals('http://localhost/custom/some-route', app('laravellocalization')->localizeURL('some-route', 'custom'));
+        $this->assertEquals('http://localhost/custom', app('laravellocalization')->localizeURL('http://localhost/custom', 'en'));
     }
 }

--- a/tests/LocalizerTests.php
+++ b/tests/LocalizerTests.php
@@ -25,7 +25,7 @@ class LocalizerTests extends \Orchestra\Testbench\BrowserKit\TestCase
         ];
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
     }

--- a/tests/LocalizerTests.php
+++ b/tests/LocalizerTests.php
@@ -786,4 +786,19 @@ class LocalizerTests extends \Orchestra\Testbench\BrowserKit\TestCase
         $this->assertEquals($must_resolve_to, $language);
     }
 
+    public function testSetLocaleWithMapping()
+    {
+        app('config')->set('laravellocalization.localesMapping', [
+            'en' => 'custom',
+        ]);
+
+        $this->assertEquals('custom', app('laravellocalization')->setLocale('custom'));
+        $this->assertEquals('en', app('laravellocalization')->getCurrentLocale());
+
+        $this->assertTrue(app('laravellocalization')->checkLocaleInSupportedLocales('en'));
+        $this->assertTrue(app('laravellocalization')->checkLocaleInSupportedLocales('custom'));
+
+        $this->assertEquals('http://localhost/custom/some-route', app('laravellocalization')->localizeURL('some-route', 'en'));
+        $this->assertEquals('http://localhost/custom/some-route', app('laravellocalization')->localizeURL('some-route', 'custom'));
+    }
 }


### PR DESCRIPTION
```php
app('config')->set('laravellocalization.localesMapping', [
    'en' => 'custom',
]);

// Route::prefix(app(...)->setLocale()) => http://localhost/cusom => custom
$this->assertEquals('custom', app('laravellocalization')->setLocale('custom'));
// Current locale is en
$this->assertEquals('en', app('laravellocalization')->getCurrentLocale());

// both are in supported locales
$this->assertTrue(app('laravellocalization')->checkLocaleInSupportedLocales('en'));
$this->assertTrue(app('laravellocalization')->checkLocaleInSupportedLocales('custom'));

// use the mapping
$this->assertEquals('http://localhost/custom/some-route', app('laravellocalization')->localizeURL('some-route', 'en'));
$this->assertEquals('http://localhost/custom/some-route', app('laravellocalization')->localizeURL('some-route', 'custom'));
```