### PR TITLE
setLocale() must return `$this->currentLocale`

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -190,7 +190,7 @@ class LaravelLocalization
             setlocale(LC_MONETARY, $regional . $suffix);
         }
 
-        return $locale;
+        return $this->currentLocale;
     }
 
     /**


### PR DESCRIPTION
setLocale() return a undefined in some case `$locale` variable, so we need to return the `$this->currentLocale` that are always set!