### PR TITLE
routes.translation event

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -6,6 +6,7 @@ use Illuminate\Config\Repository;
 use Illuminate\Contracts\Routing\UrlRoutable;
 use Mcamara\LaravelLocalization\Exceptions\SupportedLocalesNotDefined;
 use Mcamara\LaravelLocalization\Exceptions\UnsupportedLocaleException;
+use App\Models\Category;
 
 class LaravelLocalization
 {
@@ -261,6 +262,8 @@ class LaravelLocalization
         $urlQuery = parse_url($url, PHP_URL_QUERY);
         $urlQuery = $urlQuery ? '?'.$urlQuery : '';
 
+        
+        
         if (empty($url)) {
             if (!empty($this->routeName)) {
                 return $this->getURLFromRouteNameTranslated($locale, $this->routeName, $attributes, $forceDefaultLocation);
@@ -272,9 +275,13 @@ class LaravelLocalization
             $url = preg_replace('/'. preg_quote($urlQuery, '/') . '$/', '', $url);
         }
 
+        
+        
         if ($locale && $translatedRoute = $this->findTranslatedRouteByUrl($url, $attributes, $this->currentLocale)) {
             return $this->getURLFromRouteNameTranslated($locale, $translatedRoute, $attributes, $forceDefaultLocation).$urlQuery;
         }
+
+        
 
         $base_path = $this->request->getBaseUrl();
         $parsed_url = parse_url($url);
@@ -303,6 +310,7 @@ class LaravelLocalization
         $parsed_url['path'] = ltrim($parsed_url['path'], '/');
 
         if ($translatedRoute = $this->findTranslatedRouteByPath($parsed_url['path'], $url_locale)) {
+            
             return $this->getURLFromRouteNameTranslated($locale, $translatedRoute, $attributes, $forceDefaultLocation).$urlQuery;
         }
 
@@ -350,6 +358,20 @@ class LaravelLocalization
 
         if (!\is_string($locale)) {
             $locale = $this->getDefaultLocale();
+        }
+
+        if (array_key_exists('sublevels', $attributes)) {
+            $slug = Category::where('slug', $attributes['sublevels'])
+                ->orWhere('slug_it', $attributes['sublevels'])
+                ->orWhere('slug_en', $attributes['sublevels'])->first();
+
+            if(!$slug) {
+                $slug = Article::where('slug', $attributes['sublevels'])
+                    ->orWhere('slug_it', $attributes['sublevels'])
+                    ->orWhere('slug_en', $attributes['sublevels'])->first();
+            }
+
+            $attributes['sublevels'] = $slug[$locale == 'sr' ? 'slug' : 'slug_'.$locale];
         }
 
         $route = '';

--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -6,7 +6,6 @@ use Illuminate\Config\Repository;
 use Illuminate\Contracts\Routing\UrlRoutable;
 use Mcamara\LaravelLocalization\Exceptions\SupportedLocalesNotDefined;
 use Mcamara\LaravelLocalization\Exceptions\UnsupportedLocaleException;
-use App\Models\Category;
 
 class LaravelLocalization
 {

--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -360,18 +360,14 @@ class LaravelLocalization
             $locale = $this->getDefaultLocale();
         }
 
-        if (array_key_exists('sublevels', $attributes)) {
-            $slug = Category::where('slug', $attributes['sublevels'])
-                ->orWhere('slug_it', $attributes['sublevels'])
-                ->orWhere('slug_en', $attributes['sublevels'])->first();
+        $response = event('routes.translation', [$locale, $attributes]);
 
-            if(!$slug) {
-                $slug = Article::where('slug', $attributes['sublevels'])
-                    ->orWhere('slug_it', $attributes['sublevels'])
-                    ->orWhere('slug_en', $attributes['sublevels'])->first();
-            }
+        if (!empty($response)) {
+            $response = array_shift($response);
+        }
 
-            $attributes['sublevels'] = $slug[$locale == 'sr' ? 'slug' : 'slug_'.$locale];
+        if (\is_array($response)) {
+            $attributes = array_merge($attributes, $response);
         }
 
         $route = '';
@@ -929,15 +925,7 @@ class LaravelLocalization
             }
 
             $attributes = $this->normalizeAttributes($this->router->current()->parameters());
-            $response = event('routes.translation', [$locale, $attributes]);
-
-            if (!empty($response)) {
-                $response = array_shift($response);
-            }
-
-            if (\is_array($response)) {
-                $attributes = array_merge($attributes, $response);
-            }
+            
         }
 
         return $attributes;


### PR DESCRIPTION
Changed where the event `routes.translation` is firing in order to fix the issue of attributes not being translated even though the event was firing.

```
public function getURLFromRouteNameTranslated($locale, $transKeyName, $attributes = [], $forceDefaultLocation = false)
    {
        if (!$this->checkLocaleInSupportedLocales($locale)) {
            throw new UnsupportedLocaleException('Locale \''.$locale.'\' is not in the list of supported locales.');
        }

        if (!\is_string($locale)) {
            $locale = $this->getDefaultLocale();
        }

        $response = event('routes.translation', [$locale, $attributes]);

        if (!empty($response)) {
            $response = array_shift($response);
        }

        if (\is_array($response)) {
            $attributes = array_merge($attributes, $response);
        }

        $route = '';

        if ($forceDefaultLocation || !($locale === $this->defaultLocale && $this->hideDefaultLocaleInURL())) {
            $route = '/'.$locale;
        }
        if (\is_string($locale) && $this->translator->has($transKeyName, $locale)) {
            $translation = $this->translator->trans($transKeyName, [], $locale);
            $route .= '/'.$translation;

            $route = $this->substituteAttributesInRoute($attributes, $route);
        }

        if (empty($route)) {
            // This locale does not have any key for this route name
            return false;
        }

        return rtrim($this->createUrlFromUri($route), '/');
    }
```