### PR TITLE
Fixed issues with translated route caching

### DIFF
--- a/src/Mcamara/LaravelLocalization/Commands/RouteTranslationsListCommand.php
+++ b/src/Mcamara/LaravelLocalization/Commands/RouteTranslationsListCommand.php
@@ -28,11 +28,6 @@ class RouteTranslationsListCommand extends RouteListCommand
      */
     public function handle()
     {
-        if (count($this->routes) == 0) {
-            $this->error("Your application doesn't have any routes.");
-            return;
-        }
-
         $locale = $this->argument('locale');
 
         if ( ! $this->isSupportedLocale($locale)) {
@@ -40,18 +35,18 @@ class RouteTranslationsListCommand extends RouteListCommand
             return;
         }
 
-        $this->routes = $this->getFreshApplicationRoutes($locale);
+        $this->loadFreshApplicationRoutes($locale);
 
-        $this->displayRoutes($this->getRoutes());
+        parent::handle();
     }
 
     /**
-     * Boot a fresh copy of the application and get the routes.
+     * Boot a fresh copy of the application and replace the router/routes.
      *
      * @param string $locale
-     * @return \Illuminate\Routing\RouteCollection
+     * @return void
      */
-    protected function getFreshApplicationRoutes($locale)
+    protected function loadFreshApplicationRoutes($locale)
     {
         $app = require $this->getBootstrapPath() . '/app.php';
 
@@ -63,7 +58,7 @@ class RouteTranslationsListCommand extends RouteListCommand
 
         putenv("{$key}=");
 
-        return $app['router']->getRoutes();
+        $this->router = $app['router'];
     }
 
     /**

--- a/src/Mcamara/LaravelLocalization/Traits/LoadsTranslatedCachedRoutes.php
+++ b/src/Mcamara/LaravelLocalization/Traits/LoadsTranslatedCachedRoutes.php
@@ -58,8 +58,12 @@ trait LoadsTranslatedCachedRoutes
     {
         $path = $this->getDefaultCachedRoutePath();
 
-        $localeSegment = request()->segment(1);
-        if ( ! $localeSegment || ! in_array($localeSegment, $localeKeys)) {
+        // If we have no specifically forced locale, use default or let the request determine it.
+        if ($locale === null) {
+            $locale = $this->getLocaleFromRequest();
+        }
+
+        if ( ! $locale || ! in_array($locale, $localeKeys)) {
             return $path;
         }
 
@@ -74,6 +78,14 @@ trait LoadsTranslatedCachedRoutes
     protected function getDefaultCachedRoutePath()
     {
         return $this->app->getCachedRoutesPath();
+    }
+
+    /**
+     * @return string|null
+     */
+    protected function getLocaleFromRequest()
+    {
+        return request()->segment(1);
     }
 
     /**


### PR DESCRIPTION
- The list command works again in Laravel 5.8. Also, running applications in console now respects the current locale when routes are cached.
- The cache command is cleaned up.

Fixes #638.