### PR TITLE
Add test to check independece of getLocale and hideDefaultLocale

### DIFF
--- a/tests/LocalizerTests.php
+++ b/tests/LocalizerTests.php
@@ -25,11 +25,6 @@ class LocalizerTests extends \Orchestra\Testbench\BrowserKit\TestCase
         ];
     }
 
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
     /**
      * Set routes for testing.
      *
@@ -90,6 +85,41 @@ class LocalizerTests extends \Orchestra\Testbench\BrowserKit\TestCase
     }
 
     /**
+     * Create fake request
+     * @param  [type] $method     [description]
+     * @param  [type] $content    [description]
+     * @param  string $uri        [description]
+     * @param  array  $server     [description]
+     * @param  array  $parameters [description]
+     * @param  array  $cookies    [description]
+     * @param  array  $files      [description]
+     * @return [type]             [description]
+     */
+    protected function createRequest(
+        $uri = '/test',
+        $method = 'GET',
+        $parameters = [],
+        $cookies = [],
+        $files = [],
+        $server = ['CONTENT_TYPE' => 'application/json'],
+        $content = null
+    )
+    {
+        $request = new \Illuminate\Http\Request;
+        return $request->createFromBase(
+            \Symfony\Component\HttpFoundation\Request::create(
+                $uri,
+                $method,
+                $parameters,
+                $cookies,
+                $files,
+                $server,
+                $content
+            )
+        );
+    }
+
+    /**
      * Define environment setup.
      *
      * @param Illuminate\Foundation\Application $app
@@ -136,6 +166,22 @@ class LocalizerTests extends \Orchestra\Testbench\BrowserKit\TestCase
 
         $this->assertNull(app('laravellocalization')->setLocale('de'));
         $this->assertEquals('en', app('laravellocalization')->getCurrentLocale());
+    }
+
+    // LaravelLocalization setLocale method should return the locale of
+    // the request uri (if any). This behavior should be independet
+    // of the `hideDefaultLocaleInURL` setting
+    public function testHideDefaultLocaleInUrlShouldNotChangeSetLocaleBehaviour()
+    {
+        app('config')->set('laravellocalization.hideDefaultLocaleInURL', true);
+
+        app()['request'] = $this->createRequest(
+            $uri = '/en/test',
+        );
+
+        $laravelLocalization = new \Mcamara\LaravelLocalization\LaravelLocalization();
+
+        $this->assertEquals('en', $laravelLocalization->setLocale());
     }
 
     public function testLocalizeURL()

--- a/tests/LocalizerTests.php
+++ b/tests/LocalizerTests.php
@@ -176,7 +176,7 @@ class LocalizerTests extends \Orchestra\Testbench\BrowserKit\TestCase
         app('config')->set('laravellocalization.hideDefaultLocaleInURL', true);
 
         app()['request'] = $this->createRequest(
-            $uri = '/en/test',
+            $uri = '/en/test'
         );
 
         $laravelLocalization = new \Mcamara\LaravelLocalization\LaravelLocalization();


### PR DESCRIPTION
A recent change in `setLocale` caused that `hideDefaultLocaleInURL`
is causing a `404` error when an uri with default locale is accessed.
A test for this scenario has been created, but it currently fails
in release 1.4.2.

See #656 for more