### PR TITLE
Fix hideDefaultLocale

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -170,11 +170,6 @@ class LaravelLocalization
 
         if (!empty($this->supportedLocales[$locale])) {
             $this->currentLocale = $locale;
-
-            if ($locale === $this->defaultLocale && $this->hideDefaultLocaleInURL()) {
-                $locale = null;
-            }
-            
         } else {
             // if the first segment/locale passed is not valid
             // the system would ask which locale have to take

--- a/src/Mcamara/LaravelLocalization/Traits/LoadsTranslatedCachedRoutes.php
+++ b/src/Mcamara/LaravelLocalization/Traits/LoadsTranslatedCachedRoutes.php
@@ -22,9 +22,9 @@ trait LoadsTranslatedCachedRoutes
     {
         $localization = $this->getLaravelLocalization();
 
-        $localization->setLocale();
-
-        $locale = $localization->getCurrentLocale();
+        // compute $locale from url.
+        // It is null if url does not contain locale.
+        $locale = $localization->setLocale();
 
         $localeKeys = $localization->getSupportedLanguagesKeys();
 
@@ -57,11 +57,6 @@ trait LoadsTranslatedCachedRoutes
     protected function makeLocaleRoutesPath($locale, $localeKeys)
     {
         $path = $this->getDefaultCachedRoutePath();
-
-        // If we have no specifically forced locale, use default or let the request determine it.
-        if ($locale === null) {
-            $locale = $this->getLocaleFromRequest();
-        }
 
         if ( ! $locale || ! in_array($locale, $localeKeys)) {
             return $path;


### PR DESCRIPTION
A previous commit for caching (PR #651 . See line 175 in vendor/mcamara/laravel-localization/src/LaravelLocalization.) broke the functionality of `hideDefaultLocale`
(with and without cache).

The purpose of `setLocale` is to return the locale of the url (even if there is none).
This is necessary for ensuring that the current requested route actually exists.
Therefore this behavior was reestablished.

The file `bootstrap/cache/routes_**.php` imitates the routes that
are otherwise generated by the `setLocale` group in `routes/web.php`. 
Therefore, its essential that `**` has the value of the locale of the url 
(which is `setLocale`).
A nullable locale must refer to `bootstrap/cache/routes.php`.

Fixes #656
Fixes #661