### PR TITLE
Fixed getLocalizedURL producing duplicate query string

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -282,8 +282,9 @@ class LaravelLocalization
             }
         } else {
             $url = $this->url->to($url);
-            $url = preg_replace('/'. preg_quote($urlQuery, '/') . '$/', '', $url);
         }
+
+        $url = preg_replace('/'. preg_quote($urlQuery, '/') . '$/', '', $url);
 
         if ($locale && $translatedRoute = $this->findTranslatedRouteByUrl($url, $attributes, $this->currentLocale)) {
             return $this->getURLFromRouteNameTranslated($locale, $translatedRoute, $attributes, $forceDefaultLocation).$urlQuery;

--- a/tests/LocalizerTests.php
+++ b/tests/LocalizerTests.php
@@ -340,6 +340,18 @@ class LocalizerTests extends \Orchestra\Testbench\BrowserKit\TestCase
         );
     }
 
+    public function testGetLocalizedURLWithQueryStringAndNotTranslatedRoute()
+    {
+         app()['request'] = $this->createRequest(
+            $uri = 'en/about?q=2'
+        );
+        $laravelLocalization = new \Mcamara\LaravelLocalization\LaravelLocalization();
+
+        $this->assertEquals(
+            $this->test_url . 'en/about?q=2',
+            $laravelLocalization->getLocalizedURL()
+        );
+    }
 
     /**
      * @param string $path


### PR DESCRIPTION
Hello there, first pull request for me on this project

I have a bug on production with your package.
I have an non-translated route where I use the middleware 'LocaleSessionRedirect'.
'LocaleSessionRedirect' uses the 'getLocalizedURL' method which produce an url with a duplicate query string.

In my opinion the query string should be removed from the variable '$url' even when is is empty to begin with

I added the tests along the patch. ( the test wasn't passing before the patch )