### PR TITLE
Fix missing import in LocaleCookieRedirect

### DIFF
--- a/src/Mcamara/LaravelLocalization/Middleware/LocaleCookieRedirect.php
+++ b/src/Mcamara/LaravelLocalization/Middleware/LocaleCookieRedirect.php
@@ -3,6 +3,7 @@
 use Closure;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Cookie;
+use Mcamara\LaravelLocalization\LanguageNegotiator;
 
 class LocaleCookieRedirect extends LaravelLocalizationMiddlewareBase
 {

--- a/src/Mcamara/LaravelLocalization/Middleware/LocaleCookieRedirect.php
+++ b/src/Mcamara/LaravelLocalization/Middleware/LocaleCookieRedirect.php
@@ -16,39 +16,49 @@ class LocaleCookieRedirect extends LaravelLocalizationMiddlewareBase
      *
      * @return mixed
      */
-     public function handle($request, Closure $next) {
-         // If the URL of the request is in exceptions.
-         if ($this->shouldIgnore($request)) {
-             return $next($request);
-         }
+    public function handle($request, Closure $next)
+    {
+        // If the URL of the request is in exceptions.
+        if ($this->shouldIgnore($request)) {
+            return $next($request);
+        }
 
-         $params = explode('/', $request->path());
-         $locale = $request->cookie('locale', false);
+        $params = explode('/', $request->path());
+        $locale = $request->cookie('locale', false);
 
-         if (\count($params) > 0 && app('laravellocalization')->checkLocaleInSupportedLocales($params[0])) {
+        if (\count($params) > 0 && app('laravellocalization')->checkLocaleInSupportedLocales($params[0])) {
             return $next($request)->withCookie(cookie()->forever('locale', $params[0]));
-         }
-         elseif(empty($locale) && app('laravellocalization')->hideUrlAndAcceptHeader()){
-           // When default locale is hidden and accept language header is true,
-           // then compute browser language when no session has been set.
-           // Once the session has been set, there is no need
-           // to negotiate language from browser again.
-           $negotiator = new LanguageNegotiator(app('laravellocalization')->getDefaultLocale(), app('laravellocalization')->getSupportedLocales(), $request);
-           $locale     = $negotiator->negotiateLanguage();
-           Cookie::queue(Cookie::forever('locale', $locale));
-         }
+        }
 
-         if($locale === false){
-           $locale = app('laravellocalization')->getCurrentLocale();
-         }
+        if (empty($locale) && app('laravellocalization')->hideUrlAndAcceptHeader()){
+            // When default locale is hidden and accept language header is true,
+            // then compute browser language when no session has been set.
+            // Once the session has been set, there is no need
+            // to negotiate language from browser again.
+            $negotiator = new LanguageNegotiator(
+                app('laravellocalization')->getDefaultLocale(),
+                app('laravellocalization')->getSupportedLocales(),
+                $request
+            );
+            $locale = $negotiator->negotiateLanguage();
+            Cookie::queue(Cookie::forever('locale', $locale));
+        }
 
-         if ($locale && app('laravellocalization')->checkLocaleInSupportedLocales($locale) && !(app('laravellocalization')->isHiddenDefault($locale))) {
-           $redirection = app('laravellocalization')->getLocalizedURL($locale);
-           $redirectResponse = new RedirectResponse($redirection, 302, ['Vary' => 'Accept-Language']);
+        if ($locale === false){
+            $locale = app('laravellocalization')->getCurrentLocale();
+        }
 
-           return $redirectResponse->withCookie(cookie()->forever('locale', $params[0]));
-         }
+        if (
+            $locale &&
+            app('laravellocalization')->checkLocaleInSupportedLocales($locale) &&
+            !(app('laravellocalization')->isHiddenDefault($locale))
+        ) {
+            $redirection = app('laravellocalization')->getLocalizedURL($locale);
+            $redirectResponse = new RedirectResponse($redirection, 302, ['Vary' => 'Accept-Language']);
 
-         return $next($request);
-     }
+            return $redirectResponse->withCookie(cookie()->forever('locale', $params[0]));
+        }
+
+        return $next($request);
+    }
 }

--- a/src/Mcamara/LaravelLocalization/Middleware/LocaleSessionRedirect.php
+++ b/src/Mcamara/LaravelLocalization/Middleware/LocaleSessionRedirect.php
@@ -5,7 +5,6 @@ namespace Mcamara\LaravelLocalization\Middleware;
 use Closure;
 use Illuminate\Http\RedirectResponse;
 use Mcamara\LaravelLocalization\LanguageNegotiator;
-use Mcamara\LaravelLocalization\LaravelLocalization;
 
 class LocaleSessionRedirect extends LaravelLocalizationMiddlewareBase
 {
@@ -32,21 +31,30 @@ class LocaleSessionRedirect extends LaravelLocalizationMiddlewareBase
 
             return $next($request);
         }
-        elseif(empty($locale) && app('laravellocalization')->hideUrlAndAcceptHeader()){
-          // When default locale is hidden and accept language header is true,
-          // then compute browser language when no session has been set.
-          // Once the session has been set, there is no need
-          // to negotiate language from browser again.
-          $negotiator = new LanguageNegotiator(app('laravellocalization')->getDefaultLocale(), app('laravellocalization')->getSupportedLocales(), $request);
-          $locale     = $negotiator->negotiateLanguage();
-          session(['locale' => $locale]);
+
+        if (empty($locale) && app('laravellocalization')->hideUrlAndAcceptHeader()){
+            // When default locale is hidden and accept language header is true,
+            // then compute browser language when no session has been set.
+            // Once the session has been set, there is no need
+            // to negotiate language from browser again.
+            $negotiator = new LanguageNegotiator(
+                app('laravellocalization')->getDefaultLocale(),
+                app('laravellocalization')->getSupportedLocales(),
+                $request
+            );
+            $locale = $negotiator->negotiateLanguage();
+            session(['locale' => $locale]);
         }
 
-        if($locale === false){
-          $locale = app('laravellocalization')->getCurrentLocale();
+        if ($locale === false){
+            $locale = app('laravellocalization')->getCurrentLocale();
         }
 
-        if ($locale && app('laravellocalization')->checkLocaleInSupportedLocales($locale) && !(app('laravellocalization')->isHiddenDefault($locale))) {
+        if (
+            $locale &&
+            app('laravellocalization')->checkLocaleInSupportedLocales($locale) &&
+            !(app('laravellocalization')->isHiddenDefault($locale))
+        ) {
             app('session')->reflash();
             $redirection = app('laravellocalization')->getLocalizedURL($locale);
 


### PR DESCRIPTION
Change introduced with https://github.com/mcamara/laravel-localization/commit/15d378622ed741209e974a73d635b61b9b9f6795 had left `LocaleCookieRedirect` middleware unusable as `LanguageNegotiator` wasn't imported. This PR fixes the problem by adding the missing import. 

Besides that, cookie redirect middleware and session redirect middleware used inconsistent code style (indentation, empty spaces, line length...) so that is taken care of as well :slightly_smiling_face: 

Have a nice day, cheers! :slightly_smiling_face: 