### PR TITLE
Make readme more readable for freshman

### DIFF
--- a/ADDITIONS.md
+++ b/ADDITIONS.md
@@ -23,3 +23,39 @@ You may also register the `LaravelLocalization` facade:
                 'LaravelLocalization' => Mcamara\LaravelLocalization\Facades\LaravelLocalization::class,
         ],
 ```
+
+## Config
+
+### Service Providers
+
+Otherwise, you can use `ConfigServiceProviders` (check <a href="https://raw.githubusercontent.com/mcamara/laravel-localization/master/src/config/config.php">this file</a> for more info).
+
+For example, editing the default config service provider that Laravel loads when it's installed. This file is placed in `app/providers/ConfigServicePovider.php` and would look like this:
+
+```php
+<?php namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class ConfigServiceProvider extends ServiceProvider {
+	public function register()
+	{
+		config([
+			'laravellocalization.supportedLocales' => [
+				'ace' => array( 'name' => 'Achinese', 'script' => 'Latn', 'native' => 'Aceh' ),
+				'ca'  => array( 'name' => 'Catalan', 'script' => 'Latn', 'native' => 'català' ),
+				'en'  => array( 'name' => 'English', 'script' => 'Latn', 'native' => 'English' ),
+			],
+
+			'laravellocalization.useAcceptLanguageHeader' => true,
+
+			'laravellocalization.hideDefaultLocaleInURL' => true
+		]);
+	}
+
+}
+```
+
+This config would add Catalan and Achinese as languages and override any other previous supported locales and all the other options in the package.
+
+You can create your own config providers and add them on your application config file (check the providers array in `config/app.php`).

--- a/ADDITIONS.md
+++ b/ADDITIONS.md
@@ -1,0 +1,25 @@
+# Additional information
+
+## Installation
+
+### For Laravel 5.4 and below:
+
+For older versions of the framework, follow the steps below:
+
+Register the service provider in `config/app.php`
+
+```php
+        'providers' => [
+		// [...]
+                Mcamara\LaravelLocalization\LaravelLocalizationServiceProvider::class,
+        ],
+```
+
+You may also register the `LaravelLocalization` facade:
+
+```php
+        'aliases' => [
+		// [...]
+                'LaravelLocalization' => Mcamara\LaravelLocalization\Facades\LaravelLocalization::class,
+        ],
+```

--- a/README.md
+++ b/README.md
@@ -27,11 +27,8 @@ The package offers the following:
 - <a href="#helpers">Helpers</a>
 - <a href="#translated-routes">Translated Routes</a>
 - <a href="#caching-routes">Caching routes</a>
-<<<<<<< HEAD
 - <a href="#testing">Testing</a>
 - <a href="#collaborators">Collaborators</a>
-=======
->>>>>>> master
 - <a href="#changelog">Changelog</a>
 - <a href="#testing">Testing</a>
 - <a href="#common-issues">Common Issues</a>
@@ -128,7 +125,7 @@ Route::group(['prefix' => LaravelLocalization::setLocale()], function()
 
 ```
 
-Once this route group is added to the routes file, a user can access all locales added into `supportedLocales` ('en' and 'es' by default).
+Once this route group is added to the routes file, a user can access all locales added into `supportedLocales` (`en` and `es` by default).
 For example, the above route file creates the following addresses:
 
 ```
@@ -145,7 +142,7 @@ http://url-to-laravel/es/test
 http://url-to-laravel
 http://url-to-laravel/test
 ```
-The package sets your application locale `App::getLocale()` according to your url. You may translate your files as explained in [Laravel Localization docs](http://laravel.com/docs/localization).
+The package sets your application locale `App::getLocale()` according to your url. The locale may then be used for [Laravel's localization features](http://laravel.com/docs/localization).
 
 You may add middleware to your group like this:
 
@@ -215,29 +212,17 @@ aswell as the `hideDefaultLocaleInURL` and [Translated Routes](#translated-route
 #### Get localized URL
 
 ```php
-// If current locale is Spanish, it returns `/es/test`
-{{ LaravelLocalization::localizeURL('/test') }}#
-```
-
-Links may be localized like this:
-
+    // If current locale is Spanish, it returns `/es/test`
     <a href="{{ LaravelLocalization::localizeUrl('(/test)') }}">@lang('Follow this link')</a>
-
-A form may be localized like this:
-
-    <form action="{{ LaravelLocalization::localizeUrl('(/update)') }}" method="POST">
-        @csrf
-        // ...
-    </form>
+```
 
 #### Get localized URL for an specific locale
 Get current URL in specific locale:
 
 ```php
-// Returns localized url of `test` for English locale.
+// Returns current url with English locale.
 {{ LaravelLocalization::getLocalizedURL('en') }}
 ```
-
 
 ### Set view-base-path to current locale
 
@@ -268,40 +253,6 @@ LaravelLocalization::getLocalizedURL('en-GB', 'a/b/c'); // http://url-to-laravel
 LaravelLocalization::getLocalizedURL('uk', 'a/b/c'); // http://url-to-laravel/uk/a/b/c
 ```
 
-<<<<<<< HEAD
-
-=======
-## Helpers
-
-This package comes with some useful functions, like:
-
-
-### Get localized url
-
-```php
-    /**
-     * Returns an URL adapted to $locale or current locale.
-     *
-     * @param string      $url    URL to adapt. If not passed, the current url would be taken.
-     * @param string|bool $locale Locale to adapt, false to remove locale
-     *
-     * @throws UnsupportedLocaleException
-     *
-     * @return string URL translated
-     */
-    public function localizeURL($url = null, $locale = null)
-```
-
-//Should be called in a view like this:
-{{ LaravelLocalization::localizeURL('/about') }}
-
-
-It returns a URL localized to the desired locale (if no locale is given, it uses current locale).
-
-
-#### Route Model Binding
->>>>>>> master
-
 ## Helpers
 
 This package comes with a bunch of helpers.
@@ -310,57 +261,37 @@ This package comes with a bunch of helpers.
 
 Returns a URL clean of any localization.
 
-<<<<<<< HEAD
 ```php
-// Returns `/test`
-{{ LaravelLocalization::getNonLocalizedURL('/es/test') }}
-=======
 //Should be called in a view like this:
 {{ LaravelLocalization::getNonLocalizedURL('/es/about') }}
->>>>>>> master
 ```
 
 ### Get URL for an specific translation key
 
-```php
-/**
- * Returns an URL adapted to the route name and the locale given
- *
- * @throws UnsupportedLocaleException
- *
- * @param  string|boolean 		$locale 		Locale to adapt
- * @param  string 			$transKeyName  		Translation key name of the url to adapt
- * @param  array 			$attributes  		Attributes for the route (only needed if transKeyName needs them)
- *
- * @return string|false 					URL translated
- */
-public function getURLFromRouteNameTranslated($locale, $transKeyName, $attributes = array())
+Returns a route, localized to the desired locale using the locale passed. If the translation key does not exist in the locale given, this function will return false.
 
+
+```php
 //Should be called in a view like this:
 {{ LaravelLocalization::getURLFromRouteNameTranslated('es', 'routes.about') }}
 ```
 
-It returns a route, localized to the desired locale using the locale passed. If the translation key does not exist in the locale given, this function will return false.
 
 ### Get Supported Locales
 
+Return all supported locales and their properties as an array.
+
 ```php
-/**
- * Return an array of all supported Locales
- *
- * @return array
- */
-public function getSupportedLocales()
 
 //Should be called like this:
 {{ LaravelLocalization::getSupportedLocales() }}
 ```
 
-This function will return all supported locales and their properties as an array.
+
 
 ### Get Supported Locales Custom Order
 
-This function will return all supported locales but in the order specified in the configuration file. You can use this function to print locales in the language selector.
+Return all supported locales but in the order specified in the configuration file. You can use this function to print locales in the language selector.
 
 ```php
 {{ LaravelLocalization::getLocalesOrder() }}
@@ -368,7 +299,7 @@ This function will return all supported locales but in the order specified in th
 
 ### Get Supported Locales Keys
 
-This function will return an array with all the keys for the supported locales.
+Return an array with all the keys for the supported locales.
 
 ```php
 {{ LaravelLocalization::getSupportedLanguagesKeys() }}
@@ -376,14 +307,14 @@ This function will return an array with all the keys for the supported locales.
 
 ### Get Current Locale
 
-This function will return the key of the current locale.
+Return the key of the current locale.
 
 ```php
 {{ LaravelLocalization::getCurrentLocale() }}
 ```
 
 ### Get Current Locale Name
-This function will return current locale's name as string (English/Spanish/Arabic/ ..etc).
+Return current locale's name as string (English/Spanish/Arabic/ ..etc).
 
 ```php
 {{ LaravelLocalization::getCurrentLocaleName() }}
@@ -391,7 +322,7 @@ This function will return current locale's name as string (English/Spanish/Arabi
 
 ### Get Current Locale Direction
 
-This function will return current locale's direction as string (ltr/rtl).
+Return current locale's direction as string (ltr/rtl).
 
 
 ```php
@@ -401,7 +332,7 @@ This function will return current locale's direction as string (ltr/rtl).
 
 
 ### Get Current Locale Script
-This function will return the [ISO 15924](http://www.unicode.org/iso15924) code for the current locale script as a string; "Latn", "Cyrl", "Arab", etc.
+Return the [ISO 15924](http://www.unicode.org/iso15924) code for the current locale script as a string; "Latn", "Cyrl", "Arab", etc.
 
 ```php
 {{ LaravelLocalization::getCurrentLocaleScript() }}
@@ -425,7 +356,7 @@ If you're supporting multiple locales in your project you will probably want to 
 ```
 Here default language will be forced in getLocalizedURL() to be present in the URL even `hideDefaultLocaleInURL = true`.
 
-Note that <a href="#route-model-binding">Route Model Binding</a> is supported.
+Note that Route Model Binding is supported.
 
 ## Translated Routes
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,15 @@
 
 Easy i18n localization for Laravel, an useful tool to combine with Laravel localization classes.
 
-## Collaborators
-- [Adam Nielsen (iwasherefirst2)](https://github.com/iwasherefirst2)
+The package offers the following:
 
-Ask [mcamara](https://github.com/mcamara) if you want to be one of them!
+ - Detect language from browser
+ - Smart redirects (Save locale in session/cookie)
+ - Smart routing (Define your routes only once, no matter how many languages you use)
+ - Translatable Routes
+ - Supports caching & testing
+ - Option to hide default locale (for SEO)
+
 
 ## Table of Contents
 
@@ -29,6 +34,7 @@ Ask [mcamara](https://github.com/mcamara) if you want to be one of them!
 - <a href="#translated-routes">Translated Routes</a>
 - <a href="#caching-routes">Caching routes</a>
 - <a href="#testing">Testing</a>
+- <a href="#collaborators">Collaborators</a>
 - <a href="#changelog">Changelog</a>
 - <a href="#license">License</a>
 
@@ -48,27 +54,7 @@ Ask [mcamara](https://github.com/mcamara) if you want to be one of them!
 
 Install the package via composer: `composer require mcamara/laravel-localization`
 
-### For Laravel 5.4 and below:
-
-For older versions of the framework, follow the steps below:
-
-Register the service provider in `config/app.php`
-
-```php
-        'providers' => [
-		// [...]
-                Mcamara\LaravelLocalization\LaravelLocalizationServiceProvider::class,
-        ],
-```
-
-You may also register the `LaravelLocalization` facade:
-
-```php
-        'aliases' => [
-		// [...]
-                'LaravelLocalization' => Mcamara\LaravelLocalization\Facades\LaravelLocalization::class,
-        ],
-```
+For Laravel 5.4 and below it necessary to [register the service provider](/ADDITIONS.md#for-laravel-5.4-and-below).
 
 ## Config
 
@@ -595,6 +581,11 @@ public function testBasicTest()
     // Testing code
 }
 ```
+
+## Collaborators
+- [Adam Nielsen (iwasherefirst2)](https://github.com/iwasherefirst2)
+
+Ask [mcamara](https://github.com/mcamara) if you want to be one of them!
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ class Kernel extends HttpKernel {
         'localeSessionRedirect'   => \Mcamara\LaravelLocalization\Middleware\LocaleSessionRedirect::class,
         'localeCookieRedirect'    => \Mcamara\LaravelLocalization\Middleware\LocaleCookieRedirect::class,
         'localeViewPath'          => \Mcamara\LaravelLocalization\Middleware\LaravelLocalizationViewPath::class
-	];
+    ];
 }
 ```
 
@@ -140,7 +140,16 @@ http://url-to-laravel/test
 ```
 The package sets your application locale `App::getLocale()` according to your url. You may translate your files as explained in [Laravel Localization docs](http://laravel.com/docs/localization).
 
-You may add
+You may add middleware to your group like this:
+
+```php
+Route::group(
+[
+	'prefix' => LaravelLocalization::setLocale(),
+	'middleware' => [ 'localeSessionRedirect', 'localizationRedirect', 'localeViewPath' ]
+], function(){ //...
+});
+```
 
 ### Recommendations
 

--- a/README.md
+++ b/README.md
@@ -98,24 +98,38 @@ Once this route group is added to the routes file, a user can access all locales
 For example, the above route file creates the following addresses:
 
 ```
-// English localized urls
-http://url-to-laravel/en/test
-http://url-to-laravel/test
+// Set application language to English
 http://url-to-laravel/en
-http://url-to-laravel
+http://url-to-laravel/en/test
 
-// Spanish localized urls
+// Set application language to Spanish
 http://url-to-laravel/es
 http://url-to-laravel/es/test
+
+// Set application language to English or Spanish (depending on browsers default locales)
+// if nothing found set to default locale
+http://url-to-laravel
+http://url-to-laravel/test
 ```
 
-If the locale is not present in the url or it is not defined in `supportedLocales`, the system will use the application default locale or the user's browser default locale (if defined in config file).
+    ***Note***: It is **strongly** recommended to use a redirecting middleware (see next section).
+    Otherwise, when search engine robots crawl
 
-Once the locale is defined, the locale variable will be stored in a session (if the middleware is enabled), so it is not necessary to write the /lang/ section in the url after defining it once, using the last known locale for the user. If the user accesses to a different locale this session value would be changed, translating any other page he visits with the last chosen locale.
+        http://url-to-laravel
+        http://url-to-laravel/test
+
+    They may get different language content, which creates a duplicate-content issue. Therefore, to improve your SEO
+    it is recommended to redirect to `http://url-to-laravel/es` or `http://url-to-laravel/en` after the language
+    has been detected.
 
 The package sets your current locale (`App::getLocale()`) according to your url. You may translate your files as explained in [Laravel Localization docs](http://laravel.com/docs/localization).
 
-### Middleware
+### Localize Links
+
+To keep the locale all urls from your page should be localized using the [localize-url-helper](). It may be convenient to not localize all urls and use the redirect middleware.
+However, this will cause a redirect everytime the users opens a link. Also even with redirect middleware, you must localize your post routes to prevent [commen issues]().
+
+### Redirect Middleware
 
 The packages ships with useful middleware. The behavior depends on the settings of `hideDefaultLocaleInURL`
 and `useAcceptLanguageHeader` in `config/laravellocalization.php`:

--- a/README.md
+++ b/README.md
@@ -185,6 +185,36 @@ When the default locale is present in the url and `hideDefaultLocaleInURL` is se
 For example, if `es` is the default locale, then http://url-to-laravel/es/test would be redirected to http://url-to-laravel/test and the`App::getLocale()` would be
 set to `es`.
 
+### Localized URLs
+Localized URLS  taken into account [route model binding]([https://laravel.com/docs/master/routing#route-model-binding]) when generating the localized route,
+aswell as the `hideDefaultLocaleInURL` and [Translated Routes](#translated-routes) settings.
+
+
+#### Get localized URL
+
+```php
+// If current locale is Spanish, it returns `/es/test`
+{{ LaravelLocalization::localizeURL('/test') }}#
+```
+
+Links may be localized like this:
+
+    <a href="{{ LaravelLocalization::localizeUrl('(/test)') }}">@lang('Follow this link')</a>
+
+A form may be localized like this:
+
+    <form action="{{ LaravelLocalization::localizeUrl('(/update)') }}" method="POST">
+        @csrf
+        // ...
+    </form>
+
+#### Get localized URL for an specific locale
+Get current URL in specific locale:
+
+```php
+// Returns localized url of `test` for English locale.
+{{ LaravelLocalization::getLocalizedURL('en') }}
+```
 
 
 ### Set view-base-path to current locale
@@ -216,36 +246,7 @@ LaravelLocalization::getLocalizedURL('en-GB', 'a/b/c'); // http://url-to-laravel
 LaravelLocalization::getLocalizedURL('uk', 'a/b/c'); // http://url-to-laravel/uk/a/b/c
 ```
 
-### Localized URLs
-Localized URLS  taken into account [route model binding]([https://laravel.com/docs/master/routing#route-model-binding]) when generating the localized route,
-aswell as the `hideDefaultLocaleInURL` and [Translated Routes](#translated-routes) settings.
 
-
-#### Get localized URL
-
-```php
-// If current locale is Spanish, it returns `/es/test`
-{{ LaravelLocalization::localizeURL('/test') }}#
-```
-
-Links may be localized like this:
-
-    <a href="{{ LaravelLocalization::localizeUrl('(/test)') }}">@lang('Follow this link')</a>
-
-A form may be localized like this:
-
-    <form action="{{ LaravelLocalization::localizeUrl('(/update)') }}" method="POST">
-        @csrf
-        // ...
-    </form>
-
-#### Get localized URL for an specific locale
-Get current URL in specific locale:
-
-```php
-// Returns localized url of `test` for English locale.
-{{ LaravelLocalization::getLocalizedURL('en') }}
-```
 
 ## Helpers
 

--- a/README.md
+++ b/README.md
@@ -81,18 +81,18 @@ You may register the package middleware in the `app/Http/Kernel.php` file:
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
 
 class Kernel extends HttpKernel {
-	/**
-	 * The application's route middleware.
-	 *
-	 * @var array
-	 */
-	protected $routeMiddleware = [
-		/**** OTHER MIDDLEWARE ****/
-		'localize'                => \Mcamara\LaravelLocalization\Middleware\LaravelLocalizationRoutes::class,
-		'localizationRedirect'    => \Mcamara\LaravelLocalization\Middleware\LaravelLocalizationRedirectFilter::class,
-		'localeSessionRedirect'   => \Mcamara\LaravelLocalization\Middleware\LocaleSessionRedirect::class,
-            'localeCookieRedirect'    => \Mcamara\LaravelLocalization\Middleware\LocaleCookieRedirect::class,
-            'localeViewPath'          => \Mcamara\LaravelLocalization\Middleware\LaravelLocalizationViewPath::class
+    /**
+    * The application's route middleware.
+    *
+    * @var array
+    */
+    protected $routeMiddleware = [
+        /**** OTHER MIDDLEWARE ****/
+        'localize'                => \Mcamara\LaravelLocalization\Middleware\LaravelLocalizationRoutes::class,
+        'localizationRedirect'    => \Mcamara\LaravelLocalization\Middleware\LaravelLocalizationRedirectFilter::class,
+        'localeSessionRedirect'   => \Mcamara\LaravelLocalization\Middleware\LocaleSessionRedirect::class,
+        'localeCookieRedirect'    => \Mcamara\LaravelLocalization\Middleware\LocaleCookieRedirect::class,
+        'localeViewPath'          => \Mcamara\LaravelLocalization\Middleware\LaravelLocalizationViewPath::class
 	];
 }
 ```

--- a/README.md
+++ b/README.md
@@ -112,15 +112,15 @@ http://url-to-laravel
 http://url-to-laravel/test
 ```
 
-    ***Note***: It is **strongly** recommended to use a redirecting middleware (see next section).
-    Otherwise, when search engine robots crawl
+***Note***: It is **strongly** recommended to use a redirecting middleware (see next section).
+Otherwise, when search engine robots crawl
 
-        http://url-to-laravel
-        http://url-to-laravel/test
+    http://url-to-laravel
+    http://url-to-laravel/test
 
-    They may get different language content, which creates a duplicate-content issue. Therefore, to improve your SEO
-    it is recommended to redirect to `http://url-to-laravel/es` or `http://url-to-laravel/en` after the language
-    has been detected.
+They may get different language content, which creates a duplicate-content issue. Therefore, to improve your SEO
+it is recommended to redirect to `http://url-to-laravel/es` or `http://url-to-laravel/en` after the language
+has been detected.
 
 The package sets your current locale (`App::getLocale()`) according to your url. You may translate your files as explained in [Laravel Localization docs](http://laravel.com/docs/localization).
 

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ class Kernel extends HttpKernel {
 		'localize'                => \Mcamara\LaravelLocalization\Middleware\LaravelLocalizationRoutes::class,
 		'localizationRedirect'    => \Mcamara\LaravelLocalization\Middleware\LaravelLocalizationRedirectFilter::class,
 		'localeSessionRedirect'   => \Mcamara\LaravelLocalization\Middleware\LocaleSessionRedirect::class,
-        'localeCookieRedirect'    => \Mcamara\LaravelLocalization\Middleware\LocaleCookieRedirect::class,
-        'localeViewPath'          => \Mcamara\LaravelLocalization\Middleware\LaravelLocalizationViewPath::class
+            'localeCookieRedirect'    => \Mcamara\LaravelLocalization\Middleware\LocaleCookieRedirect::class,
+            'localeViewPath'          => \Mcamara\LaravelLocalization\Middleware\LaravelLocalizationViewPath::class
 	];
 }
 ```

--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ Note that the separate [czim/laravel-localization-route-cache](https://github.co
 ## Testing
 
 During the test setup, the called route is not yet known. This means no language can be set.
-When a request is made during a test, this results in a 404 - without the prefix set the localised route does not seem to exist.
+When a request is made during a test, this results in a 404 - without the prefix set the localized route does not seem to exist.
 
 To fix this, you can use this function to manually set the language prefix:
 ```php

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ The package offers the following:
     - <a href="#redirect-middleware">Redirect Middleware</a>
     - <a href="#localize-links">Localize links</a>
 - <a href="#helpers">Helpers</a>
-    - <a href="#route-model-binding">Route Model Binding</a>
 - <a href="#translated-routes">Translated Routes</a>
 - <a href="#caching-routes">Caching routes</a>
 - <a href="#testing">Testing</a>

--- a/README.md
+++ b/README.md
@@ -262,17 +262,17 @@ This package comes with a bunch of helpers.
 Returns a URL clean of any localization.
 
 ```php
-//Should be called in a view like this:
+// Returns /about
 {{ LaravelLocalization::getNonLocalizedURL('/es/about') }}
 ```
 
 ### Get URL for an specific translation key
 
-Returns a route, localized to the desired locale using the locale passed. If the translation key does not exist in the locale given, this function will return false.
+Returns a route, [localized](#translated-routes) to the desired locale. If the translation key does not exist in the locale given, this function will return false.
 
 
 ```php
-//Should be called in a view like this:
+// Returns /es/acerca
 {{ LaravelLocalization::getURLFromRouteNameTranslated('es', 'routes.about') }}
 ```
 
@@ -282,8 +282,6 @@ Returns a route, localized to the desired locale using the locale passed. If the
 Return all supported locales and their properties as an array.
 
 ```php
-
-//Should be called like this:
 {{ LaravelLocalization::getSupportedLocales() }}
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,18 +22,17 @@ The package offers the following:
 
 - <a href="#installation">Installation</a>
 - <a href="#usage">Usage</a>
-    - <a href="#redirect-middleware">Redirect Middleware</a>
+- <a href="#redirect-middleware">Redirect Middleware</a>
 - <a href="#helpers">Helpers</a>
 - <a href="#translated-routes">Translated Routes</a>
 - <a href="#caching-routes">Caching routes</a>
-- <a href="#testing">Testing</a>
-- <a href="#collaborators">Collaborators</a>
-- <a href="#changelog">Changelog</a>
 - <a href="#testing">Testing</a>
 - <a href="#common-issues">Common Issues</a>
     - <a href="#post-is-not-working">POST is not working</a>
     - <a href="#methodnotallowedhttpexception">MethodNotAllowedHttpException</a>
     - <a href="#validation-message-is-only-in-default-locale">Validation message is always in default locale</a>
+- <a href="#collaborators">Collaborators</a>
+- <a href="#changelog">Changelog</a>
 - <a href="#license">License</a>
 
 ## Laravel compatibility
@@ -166,12 +165,12 @@ Otherwise, you will cause at least one redirect each time a user clicks on a lin
 Also, any action url from a post form must be localized, to prevent that it gets redirected to a get request.
 
 
-### Redirect Middleware
+## Redirect Middleware
 
 The following redirection middleware depends on the settings of `hideDefaultLocaleInURL`
 and `useAcceptLanguageHeader` in `config/laravellocalization.php`:
 
-#### LocaleSessionRedirect
+### LocaleSessionRedirect
 
 Whenever a locale is present in the url, it will be stored in the session by this middleware.
 
@@ -182,7 +181,7 @@ In there is no locale present in the url, then this middleware will check the fo
 
 For example, if a user navigates to http://url-to-laravel/test  and `en` is the current locale, it would redirect him automatically to http://url-to-laravel/en/test.
 
-#### LocaleCookieRedirect
+### LocaleCookieRedirect
 
 Similar to LocaleSessionRedirect, but it stores value in a cookie instead of a session.
 
@@ -196,7 +195,7 @@ In there is no locale present in the url, then this middleware will check the fo
 For example, if a user navigates to http://url-to-laravel/test  and `de` is the current locale, it would redirect him automatically to http://url-to-laravel/de/test.
 
 
-#### LaravelLocalizationRedirectFilter
+### LaravelLocalizationRedirectFilter
 
 When the default locale is present in the url and `hideDefaultLocaleInURL` is set to true, then the middleware redirects to the url without locale.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ The package offers the following:
 - <a href="#installation">Installation</a>
 - <a href="#usage">Usage</a>
     - <a href="#redirect-middleware">Redirect Middleware</a>
-    - <a href="#localize-links">Localize links</a>
 - <a href="#helpers">Helpers</a>
 - <a href="#translated-routes">Translated Routes</a>
 - <a href="#caching-routes">Caching routes</a>
@@ -204,6 +203,11 @@ When the default locale is present in the url and `hideDefaultLocaleInURL` is se
 For example, if `es` is the default locale, then http://url-to-laravel/es/test would be redirected to http://url-to-laravel/test and the`App::getLocale()` would be
 set to `es`.
 
+
+## Helpers
+
+This package comes with a bunch of helpers.
+
 ### Localized URLs
 Localized URLS  taken into account [route model binding]([https://laravel.com/docs/master/routing#route-model-binding]) when generating the localized route,
 aswell as the `hideDefaultLocaleInURL` and [Translated Routes](#translated-routes) settings.
@@ -223,39 +227,6 @@ Get current URL in specific locale:
 // Returns current url with English locale.
 {{ LaravelLocalization::getLocalizedURL('en') }}
 ```
-
-### Set view-base-path to current locale
-
-Register the middleware `LaravelLocalizationViewPath` to set current locale as view-base-path.
-
-Now you can wrap your views in language-based folders like the translation files.
-
-`resources/views/en/`, `resources/views/fr`, ...
-
-
-### Map your own custom lang url segments
-
-As you can modify the supportedLocales even by renaming their keys, it is possible to use the string ```uk``` instead of ```en-GB``` to provide custom lang url segments. Of course, you need to prevent any collisions with already existing keys and should stick to the convention as long as possible. But if you are using such a custom key, you have to store your mapping to the ```localesMapping``` array. This ```
-localesMapping``` is needed to enable the LanguageNegotiator to correctly assign the desired locales based on HTTP Accept Language Header. Here is a quick example how to map HTTP Accept Language Header 'en-GB' to url segment 'uk':
-
-```php
-// config/laravellocalization.php
-
-'localesMapping' => [
-	'en-GB' => 'uk'
-],
-```
-
-After that ```http://url-to-laravel/en-GB/a/b/c``` becomes ```http://url-to-laravel/uk/a/b/c```.
-
-```php
-LaravelLocalization::getLocalizedURL('en-GB', 'a/b/c'); // http://url-to-laravel/uk/a/b/c
-LaravelLocalization::getLocalizedURL('uk', 'a/b/c'); // http://url-to-laravel/uk/a/b/c
-```
-
-## Helpers
-
-This package comes with a bunch of helpers.
 
 ### Get Clean routes
 
@@ -336,6 +307,34 @@ Return the [ISO 15924](http://www.unicode.org/iso15924) code for the current loc
 {{ LaravelLocalization::getCurrentLocaleScript() }}
 ```
 
+### Set view-base-path to current locale
+
+Register the middleware `LaravelLocalizationViewPath` to set current locale as view-base-path.
+
+Now you can wrap your views in language-based folders like the translation files.
+
+`resources/views/en/`, `resources/views/fr`, ...
+
+
+### Map your own custom lang url segments
+
+As you can modify the supportedLocales even by renaming their keys, it is possible to use the string ```uk``` instead of ```en-GB``` to provide custom lang url segments. Of course, you need to prevent any collisions with already existing keys and should stick to the convention as long as possible. But if you are using such a custom key, you have to store your mapping to the ```localesMapping``` array. This ```
+localesMapping``` is needed to enable the LanguageNegotiator to correctly assign the desired locales based on HTTP Accept Language Header. Here is a quick example how to map HTTP Accept Language Header 'en-GB' to url segment 'uk':
+
+```php
+// config/laravellocalization.php
+
+'localesMapping' => [
+	'en-GB' => 'uk'
+],
+```
+
+After that ```http://url-to-laravel/en-GB/a/b/c``` becomes ```http://url-to-laravel/uk/a/b/c```.
+
+```php
+LaravelLocalization::getLocalizedURL('en-GB', 'a/b/c'); // http://url-to-laravel/uk/a/b/c
+LaravelLocalization::getLocalizedURL('uk', 'a/b/c'); // http://url-to-laravel/uk/a/b/c
+```
 
 ## Creating a language selector
 

--- a/README.md
+++ b/README.md
@@ -91,11 +91,10 @@ class Kernel extends HttpKernel {
 		'localize'                => \Mcamara\LaravelLocalization\Middleware\LaravelLocalizationRoutes::class,
 		'localizationRedirect'    => \Mcamara\LaravelLocalization\Middleware\LaravelLocalizationRedirectFilter::class,
 		'localeSessionRedirect'   => \Mcamara\LaravelLocalization\Middleware\LocaleSessionRedirect::class,
-        'localeCookieRedirect'   => \Mcamara\LaravelLocalization\Middleware\LocaleCookieRedirect::class,
+        'localeCookieRedirect'    => \Mcamara\LaravelLocalization\Middleware\LocaleCookieRedirect::class,
         'localeViewPath'          => \Mcamara\LaravelLocalization\Middleware\LaravelLocalizationViewPath::class
 	];
 }
-
 ```
 
 ## Usage
@@ -146,17 +145,18 @@ You may add
 ### Recommendations
 
 ***1.***: It is **strongly** recommended to use a [redirecting middleware](#redirect-middleware).
+Urls without locale should only be used to determine browser/default locale and to redirect to the [localized url](#localized-urls).
 Otherwise, when search engine robots crawl for example `http://url-to-laravel/test` they may get different language content for each visit.
 Also having multiple urls for the same content creates a SEO duplicate-content issue.
 
-***2.***: It is **strongly** recommended to localize all of your links, even if you use a redirect middleware.
+***2.***: It is **strongly** recommended to [localize your links](#localized-urls), even if you use a redirect middleware.
 Otherwise, you will cause at least one redirect each time a user clicks on a link.
-Also, any action url from a post form must be localized, otherwise you will run into many [issues]().
+Also, any action url from a post form must be localized, to prevent that it gets redirected to a get request.
 
 
 ### Redirect Middleware
 
-The packages ships with useful middleware. The behavior depends on the settings of `hideDefaultLocaleInURL`
+The following redirection middleware depends on the settings of `hideDefaultLocaleInURL`
 and `useAcceptLanguageHeader` in `config/laravellocalization.php`:
 
 #### LocaleSessionRedirect
@@ -208,12 +208,12 @@ LaravelLocalization::getLocalizedURL('en-GB', 'a/b/c'); // http://url-to-laravel
 LaravelLocalization::getLocalizedURL('uk', 'a/b/c'); // http://url-to-laravel/uk/a/b/c
 ```
 
-## Localized URLs
+### Localized URLs
 Localized URLS  taken into account [route model binding]([https://laravel.com/docs/master/routing#route-model-binding]) when generating the localized route,
 aswell as the `hideDefaultLocaleInURL` and [Translated Routes](#translated-routes) settings.
 
 
-### Get localized URL
+#### Get localized URL
 
 ```php
 // If current locale is Spanish, it returns `/es/test`
@@ -231,7 +231,7 @@ A form may be localized like this:
         // ...
     </form>
 
-### Get localized URL for an specific locale
+#### Get localized URL for an specific locale
 Get current URL in specific locale:
 
 ```php

--- a/README.md
+++ b/README.md
@@ -15,18 +15,12 @@ The package offers the following:
  - Smart routing (Define your routes only once, no matter how many languages you use)
  - Translatable Routes
  - Supports caching & testing
- - Option to hide default locale (for SEO)
-
+ - Option to hide default locale in url
+ - Many snippets and helpers (like language selector)
 
 ## Table of Contents
 
 - <a href="#installation">Installation</a>
-    - <a href="#composer">Composer</a>
-    - <a href="#manually">Manually</a>
-    - <a href="#laravel">Laravel</a>
-- <a href="#config">Config</a>
-    - <a href="#config-files">Config files</a>
-    - <a href="#service-providers">Service providers</a>
 - <a href="#usage">Usage</a>
     - <a href="#middleware">Middleware</a>
 - <a href="#helpers">Helpers</a>
@@ -56,59 +50,32 @@ Install the package via composer: `composer require mcamara/laravel-localization
 
 For Laravel 5.4 and below it necessary to [register the service provider](/ADDITIONS.md#for-laravel-5.4-and-below).
 
-## Config
-
 ### Config Files
 
-In order to edit the default configuration (where for e.g. you can find `supportedLocales`) for this package you may execute:
+In order to edit the default configuration you may execute:
 
 ```
 php artisan vendor:publish --provider="Mcamara\LaravelLocalization\LaravelLocalizationServiceProvider"
 ```
 
-After that, `config/laravellocalization.php` will be created. Inside this file you will find all the fields that can be edited in this package.
+After that, `config/laravellocalization.php` will be created.
 
-### Service Providers
+The configuration options are:
 
-Otherwise, you can use `ConfigServiceProviders` (check <a href="https://raw.githubusercontent.com/mcamara/laravel-localization/master/src/config/config.php">this file</a> for more info).
-
-For example, editing the default config service provider that Laravel loads when it's installed. This file is placed in `app/providers/ConfigServicePovider.php` and would look like this:
-
-```php
-<?php namespace App\Providers;
-
-use Illuminate\Support\ServiceProvider;
-
-class ConfigServiceProvider extends ServiceProvider {
-	public function register()
-	{
-		config([
-			'laravellocalization.supportedLocales' => [
-				'ace' => array( 'name' => 'Achinese', 'script' => 'Latn', 'native' => 'Aceh' ),
-				'ca'  => array( 'name' => 'Catalan', 'script' => 'Latn', 'native' => 'català' ),
-				'en'  => array( 'name' => 'English', 'script' => 'Latn', 'native' => 'English' ),
-			],
-
-			'laravellocalization.useAcceptLanguageHeader' => true,
-
-			'laravellocalization.hideDefaultLocaleInURL' => true
-		]);
-	}
-
-}
-```
-
-This config would add Catalan and Achinese as languages and override any other previous supported locales and all the other options in the package.
-
-You can create your own config providers and add them on your application config file (check the providers array in `config/app.php`).
-
+ - **supportedLocales** Langauges of your app (Default: English & Spanish).
+ - **useAcceptLanguageHeader** If true, then automatically detect language from browser.
+ - **hideDefaultLocaleInURL** If true, then do not show default locale in url.
+ - **localesOrder** Sort languages in custom order.
+ - **localesMapping** Rename url locales.
+ - **utf8suffix** Allow changing utf8suffix for CentOS etc.
+ - **urlsIgnored** Ignore specific urls.
 
 ## Usage
 
-Laravel Localization uses the URL given for the request. In order to achieve this purpose, a route group should be added into the `routes.php` file. It will filter all pages that must be localized.
+Add the following to your routes file:
 
 ```php
-// app/Http/routes.php
+// routes/web.php
 
 Route::group(['prefix' => LaravelLocalization::setLocale()], function()
 {
@@ -127,19 +94,26 @@ Route::group(['prefix' => LaravelLocalization::setLocale()], function()
 
 ```
 
-Once this route group is added to the routes file, a user can access all locales added into `supportedLocales` ('en' and 'es' by default, look at the config section to change that option). For example, a user can now access two different locales, using the following addresses:
+Once this route group is added to the routes file, a user can access all locales added into `supportedLocales` ('en' and 'es' by default).
+For example, the above route file creates the following addresses:
 
 ```
+// English localized urls
+http://url-to-laravel/en/test
+http://url-to-laravel/test
 http://url-to-laravel/en
-http://url-to-laravel/es
 http://url-to-laravel
+
+// Spanish localized urls
+http://url-to-laravel/es
+http://url-to-laravel/es/test
 ```
 
 If the locale is not present in the url or it is not defined in `supportedLocales`, the system will use the application default locale or the user's browser default locale (if defined in config file).
 
 Once the locale is defined, the locale variable will be stored in a session (if the middleware is enabled), so it is not necessary to write the /lang/ section in the url after defining it once, using the last known locale for the user. If the user accesses to a different locale this session value would be changed, translating any other page he visits with the last chosen locale.
 
-Template files and all locale files should follow the [Lang class](http://laravel.com/docs/5.0/localization).
+The package sets your current locale (`App::getLocale()`) according to your url. You may translate your files as explained in [Laravel Localization docs](http://laravel.com/docs/localization).
 
 ### Middleware
 


### PR DESCRIPTION
This is a proposal how to change the structure of the readme to make it more readable for freshman (you may take a look at https://github.com/iwasherefirst2/laravel-localization/tree/changeReadmeALot).

I came up with this after closing a lot of issues and realizing there were 3 mayor problems

1. People did not know what this package offers and what not 
2. People were confused how and when to use middleware 
3. People did not localize POST urls.

Proposed changes:

 - Add list of features that the package offers as a summary on top
 - Move Collaborators to bottom for readability
 - Move installation of outdated Laravel 5.4< on extra Additions.md page
 - Move Config/Middleware setup into installation section
 - Name 8 config settings in readme (when you look first time into the config file, you think its more complicated as it is).
 - Create extra secction for redirecting middleware 
 - Clean up dead links of ToC 
 - Cleanup the helpers (The PHPDocs should not be in the readme.md file)
 - Add two recommendations in usage section:
   - 1. Recommend to use redirecting middleware 
   - 2. Recommend to localoze urls.