### PR TITLE
Add translatable route parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,9 +583,16 @@ Be sure to pass the locale and the attributes as parameters to the closure. You 
 
 ## Caching routes
 
-More information on support on [cached (translated) routes here](CACHING.md).
+To cache your routes, use:
 
-Note that the separate [czim/laravel-localization-route-cache](https://github.com/czim/laravel-localization-route-cache) package is no longer required.
+``` bash
+php artisan route:trans:cache
+```
+
+... instead of the normal `route:cache` command.
+
+
+For more details see [here](CACHING.md).
 
 ## Common Issues
 

--- a/README.md
+++ b/README.md
@@ -389,8 +389,13 @@ You may use translatable slugs for your model, for example like this:
     http://url/en/view/five
     http://url/es/ver/cinco
 
-For this, your model needs to implement `\Mcamara\LaravelLocalization\Interfaces` and implement
+It is required that your model implements `\Mcamara\LaravelLocalization\Interfaces` and implement
 a function `getLocalizedRouteKey($locale)` that gives for a given locale the translated slug.
+This is necessary so that your urls will be correctly [localized](#localized-urls).
+
+Also, to use [route-model-binding](https://laravel.com/docs/routing#route-model-binding), you should overwrite the function `resolveRouteBinding($value)`
+in your model. The function should return the model that belongs to the translated slug `$value`.
+
 
 ## Events
 

--- a/README.md
+++ b/README.md
@@ -394,7 +394,16 @@ The function `getLocalizedRouteKey($locale)` must return for a given locale the 
 This is necessary so that your urls will be correctly [localized](#localized-urls).
 
 Also, to use [route-model-binding](https://laravel.com/docs/routing#route-model-binding), you should overwrite the function `resolveRouteBinding($value)`
-in your model. The function should return the model that belongs to the translated slug `$value`.
+in your model. The function should return the model that belongs to the translated slug `$value`. 
+For example:
+
+```php
+public function resolveRouteBinding($value)
+{
+        return static::findByLocalizedSlug($value)->first() ?? abort(404);
+}
+```
+
 
 
 ## Events

--- a/README.md
+++ b/README.md
@@ -358,53 +358,8 @@ Note that Route Model Binding is supported.
 
 You can adapt your URLs depending on the language you want to show them. For example, http://url/en/about and http://url/es/acerca (acerca is about in spanish) or http://url/en/view/5 and http://url/es/ver/5 (view == ver in spanish) would be redirected to the same controller using the proper filter and setting up the translation files as follows:
 
-As it is a middleware, first you have to register in on your `app/Http/Kernel.php` file like this:
+It is necessary that the `localize` middleware in loaded in your `Route::group` middleware (See [installation instruction](#LaravelLocalizationRoutes)).
 
-```php
-<?php namespace App\Http;
-
-use Illuminate\Foundation\Http\Kernel as HttpKernel;
-
-class Kernel extends HttpKernel {
-	/**
-	 * The application's route middleware.
-	 *
-	 * @var array
-	 */
-	protected $routeMiddleware = [
-		/**** OTHER MIDDLEWARE ****/
-		'localize' => 'Mcamara\LaravelLocalization\Middleware\LaravelLocalizationRoutes',
-		// TRANSLATE ROUTES MIDDLEWARE
-	];
-}
-```
-
-```php
-// app/Http/routes.php
-
-Route::group(
-[
-	'prefix' => LaravelLocalization::setLocale(),
-	'middleware' => [ 'localize' ] // Route translate middleware
-],
-function() {
-	/** ADD ALL LOCALIZED ROUTES INSIDE THIS GROUP **/
-	Route::get('/', function() {
-		// This routes is useless to translate
-		return View::make('hello');
-	});
-
-	Route::get(LaravelLocalization::transRoute('routes.about'), function() {
-		return View::make('about');
-	});
-
-	Route::get(LaravelLocalization::transRoute('routes.view'), function($id) {
-		return View::make('view',['id'=>$id]);
-	});
-});
-
-/** OTHER PAGES THAT SHOULD NOT BE LOCALIZED **/
-```
 In the routes file you just have to add the `LaravelLocalizationRoutes` filter and the `LaravelLocalization::transRoute` function to every route you want to translate using the translation key.
 
 Then you have to create the translation files and add there every key you want to translate. I suggest to create a routes.php file inside your `resources/lang/language_abbreviation` folder. For the previous example, I have created two translations files, these two files would look like:
@@ -426,6 +381,16 @@ return [
 ```
 
 Once files are saved, you can access to http://url/en/about , http://url/es/acerca , http://url/en/view/5 and http://url/es/ver/5 without any problem.
+
+### Translatable route parameters
+
+You may use translatable slugs for your model, for example like this:
+
+    http://url/en/view/five
+    http://url/es/ver/cinco
+
+For this, your model needs to implement `\Mcamara\LaravelLocalization\Interfaces` and implement
+a function `getLocalizedRouteKey($locale)` that gives for a given locale the translated slug.
 
 ## Events
 

--- a/README.md
+++ b/README.md
@@ -389,8 +389,8 @@ You may use translatable slugs for your model, for example like this:
     http://url/en/view/five
     http://url/es/ver/cinco
 
-It is required that your model implements `\Mcamara\LaravelLocalization\Interfaces` and implement
-a function `getLocalizedRouteKey($locale)` that gives for a given locale the translated slug.
+For this, your model needs to implement `\Mcamara\LaravelLocalization\Interfaces\LocalizedUrlRoutable`.
+The function `getLocalizedRouteKey($locale)` must return for a given locale the translated slug.
 This is necessary so that your urls will be correctly [localized](#localized-urls).
 
 Also, to use [route-model-binding](https://laravel.com/docs/routing#route-model-binding), you should overwrite the function `resolveRouteBinding($value)`

--- a/src/Mcamara/LaravelLocalization/Interfaces/LocalizedUrlRoutable.php
+++ b/src/Mcamara/LaravelLocalization/Interfaces/LocalizedUrlRoutable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Mcamara\LaravelLocalization\Interfaces;
+
+interface LocalizedUrlRoutable
+{
+    /**
+     * Get the value of the model's localized route key.
+     *
+     * @return mixed
+     */
+    public function getLocalizedRouteKey($locale);
+}

--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -379,7 +379,7 @@ class LaravelLocalization
             $translation = $this->translator->get($transKeyName, [], $locale);
             $route .= '/'.$translation;
 
-            $route = $this->substituteAttributesInRoute($attributes, $route);
+            $route = $this->substituteAttributesInRoute($attributes, $route, $locale);
         }
 
         if (empty($route)) {
@@ -635,10 +635,13 @@ class LaravelLocalization
      *
      * @return string route with attributes changed
      */
-    protected function substituteAttributesInRoute($attributes, $route)
+    protected function substituteAttributesInRoute($attributes, $route, $locale = null)
     {
         foreach ($attributes as $key => $value) {
-            if ($value instanceOf UrlRoutable) {
+            if ($value instanceOf Interfaces\LocalizedUrlRoutable) {
+                $value = $value->getLocalizedRouteKey($locale);
+            }
+            elseif ($value instanceOf UrlRoutable) {
                 $value = $value->getRouteKey();
             }
             $route = str_replace(array('{'.$key.'}', '{'.$key.'?}'), $value, $route);
@@ -701,7 +704,7 @@ class LaravelLocalization
         $path = trim(str_replace('/'.$this->currentLocale.'/', '', $path), "/");
 
         foreach ($this->translatedRoutes as $route) {
-            if (trim($this->substituteAttributesInRoute($attributes, $this->translator->get($route)), '/') === $path) {
+            if (trim($this->substituteAttributesInRoute($attributes, $this->translator->get($route), $this->currentLocale), '/') === $path) {
                 return $route;
             }
         }

--- a/tests/LocalizerTests.php
+++ b/tests/LocalizerTests.php
@@ -596,15 +596,15 @@ class LocalizerTests extends \Orchestra\Testbench\BrowserKit\TestCase
     {
         $model = new ModelWithTranslatableRoutes();
 
-       $this->assertEquals(
-           $this->test_url.'en/view/company',
-           app('laravellocalization')->getURLFromRouteNameTranslated('en', 'LaravelLocalization::routes.view', ['id' => $model])
-       );
+        $this->assertEquals(
+            $this->test_url.'en/view/company',
+            app('laravellocalization')->getURLFromRouteNameTranslated('en', 'LaravelLocalization::routes.view', ['id' => $model])
+        );
 
-       $this->assertEquals(
-           $this->test_url.'es/ver/empresa',
-           app('laravellocalization')->getURLFromRouteNameTranslated('es', 'LaravelLocalization::routes.view', ['id' => $model])
-       );
+        $this->assertEquals(
+            $this->test_url.'es/ver/empresa',
+            app('laravellocalization')->getURLFromRouteNameTranslated('es', 'LaravelLocalization::routes.view', ['id' => $model])
+        );
     }
 
     public function testGetNonLocalizedURL()

--- a/tests/LocalizerTests.php
+++ b/tests/LocalizerTests.php
@@ -592,6 +592,21 @@ class LocalizerTests extends \Orchestra\Testbench\BrowserKit\TestCase
         );
     }
 
+    public function testLocalizedParameterFromTranslateUrl()
+    {
+        $model = new ModelWithTranslatableRoutes();
+
+       $this->assertEquals(
+           $this->test_url.'en/view/company',
+           app('laravellocalization')->getURLFromRouteNameTranslated('en', 'LaravelLocalization::routes.view', ['id' => $model])
+       );
+
+       $this->assertEquals(
+           $this->test_url.'es/ver/empresa',
+           app('laravellocalization')->getURLFromRouteNameTranslated('es', 'LaravelLocalization::routes.view', ['id' => $model])
+       );
+    }
+
     public function testGetNonLocalizedURL()
     {
         $this->assertEquals(

--- a/tests/ModelWithTranslatableRoutes.php
+++ b/tests/ModelWithTranslatableRoutes.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Database\Eloquent\Model;
+use Mcamara\LaravelLocalization\Interfaces\LocalizedUrlRoutable;
+
+class ModelWithTranslatableRoutes extends Model implements LocalizedUrlRoutable
+{
+    public function getLocalizedRouteKey($locale)
+    {
+        if($locale == 'es'){
+            return 'empresa';
+        }
+
+        return 'company';
+    }
+}


### PR DESCRIPTION
To make route parameters translatable, a model is required to have multiple translated slugs (one for each language). There is no default way to add multiple slugs for one model, so users have to create this manually.

To add this functionality the user has to provide the package access to the slug of a model for every locale. For that purpose, the model should implement the new introduced `LocalizedUrlRoutable` interface. The interface comes with only one function `getLocalizedRouteKey($locale)` which returns the localized slug for the model. 

When a model has implemented the interface, the functions `localizeUrl`, `getLocalizedURL` or `getURLFromRouteNameTranslated` etc. will also translate the parameter.

For example, when the translated route in `en/routes.php` looks like this

    [ 'page' => 'site/{title}` ]

The parameter will be also translated with `localizeUrl`, `getLocalizedURL` or `getURLFromRouteNameTranslated` etc.:

```
https://mon-site/en/site/my-title
https://mon-site/fr/pagé/mon-titre
https://mon-site/es/pagina/mi-titulo
```

Updated the readme for this and added a test.

Fixes #502 
Fixes #562  
Fixes #535 
Fixes #504
Fixes #413 