### PR TITLE
Improve translatable url section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,8 @@ Note that Route Model Binding is supported.
 
 ## Translated Routes
 
-You can adapt your URLs depending on the language you want to show them. For example, http://url/en/about and http://url/es/acerca (acerca is about in spanish) or http://url/en/article/5 and http://url/es/articulo/5 (view == ver in spanish) would be redirected to the same controller using the proper filter and setting up the translation files as follows:
+You can translate your URL. For example, http://url/en/about and http://url/es/acerca (acerca is about in spanish)
+or http://url/en/article/5 and http://url/es/articulo/5 (article is articulo in spanish) would be redirected to the same controller using the proper filter and setting up the translation files as follows:
 
 It is necessary that the `localize` middleware in loaded in your `Route::group` middleware (See [installation instruction](#LaravelLocalizationRoutes)).
 
@@ -408,21 +409,21 @@ Once files are saved, you can access to http://url/en/about , http://url/es/acer
 
 You may use translatable slugs for your model, for example like this:
 
-    http://url/en/view/five
-    http://url/es/ver/cinco
+    http://url/en/article/important-change
+    http://url/es/articulo/cambio-importante
 
 For this, your model needs to implement `\Mcamara\LaravelLocalization\Interfaces\LocalizedUrlRoutable`.
 The function `getLocalizedRouteKey($locale)` must return for a given locale the translated slug.
 This is necessary so that your urls will be correctly [localized](#localized-urls).
 
-Also, to use [route-model-binding](https://laravel.com/docs/routing#route-model-binding), you should overwrite the function `resolveRouteBinding($value)`
-in your model. The function should return the model that belongs to the translated slug `$value`.
+Also, to use [route-model-binding](https://laravel.com/docs/routing#route-model-binding), you should overwrite the function `resolveRouteBinding($slug)`
+in your model. The function should return the model that belongs to the translated slug `$slug`.
 For example:
 
 ```php
-public function resolveRouteBinding($value)
+public function resolveRouteBinding($slug)
 {
-        return static::findByLocalizedSlug($value)->first() ?? abort(404);
+        return static::findByLocalizedSlug($slug)->first() ?? abort(404);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -413,12 +413,12 @@ It is possible to have translated slugs, for example like this:
     http://url/es/articulo/cambio-importante
 
 However, in order to do this, each article must have many slugs (one for each locale).
-Its up to you how you want to implement this relation. The only requirements for translatable route parameters is that the relevant model implements the interface `LocalizedUrlRoutable` and adjusts the route-model-binding.
+Its up to you how you want to implement this relation. The only requirement for translatable route parameters is, that the relevant model implements the interface `LocalizedUrlRoutable`.
 
 #### Implementing LocalizedUrlRoutable
 
 To implement `\Mcamara\LaravelLocalization\Interfaces\LocalizedUrlRoutable`,
-one has to create the function `getLocalizedRouteKey($locale)`, which must return for a given locale the translated slug. For example, in the above example, `getLocalizedRouteKey('en')` should return `important-change` and `getLocalizedRouteKey('es')` should return `cambio-importante`.
+one has to create the function `getLocalizedRouteKey($locale)`, which must return for a given locale the translated slug. In the above example, inside the model article, `getLocalizedRouteKey('en')` should return `important-change` and `getLocalizedRouteKey('es')` should return `cambio-importante`.
 
 #### Route Model Binding
 
@@ -433,7 +433,9 @@ public function resolveRouteBinding($slug)
 }
 ```
 
-You may want to checkout this [video](https://youtu.be/B1AUqCdizgc) which demonstrates how one may set it up.
+#### Tutorial Video
+
+You may want to checkout this [video](https://youtu.be/B1AUqCdizgc) which demonstrates how one may set up translatable route parameters.
 
 ## Events
 

--- a/README.md
+++ b/README.md
@@ -368,16 +368,16 @@ The file contains an array with all translatable routes. For example, like this:
 <?php
 // resources/lang/en/routes.php
 return [
-  "about"   =>  "about",
-  "article" =>  "article/{article}",
+    "about"    =>  "about",
+    "article"  =>  "article/{article}",
 ];
 ```
 ```php
 <?php
 // resources/lang/es/routes.php
 return [
-  "about"   =>  "acerca",
-  "article"	=>  "articulo/{article}",
+    "about"    =>  "acerca",
+    "article"  =>  "articulo/{article}",
 ];
 ```
 

--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ public function resolveRouteBinding($slug)
 }
 ```
 
-
+You may want to checkout this [video](https://youtu.be/B1AUqCdizgc) which demonstrates how one may set it up.
 
 ## Events
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The package offers the following:
  - Supports caching & testing
  - Option to hide default locale in url
  - Many snippets and helpers (like language selector)
+ - Something important
 
 ## Table of Contents
 
@@ -394,7 +395,7 @@ The function `getLocalizedRouteKey($locale)` must return for a given locale the 
 This is necessary so that your urls will be correctly [localized](#localized-urls).
 
 Also, to use [route-model-binding](https://laravel.com/docs/routing#route-model-binding), you should overwrite the function `resolveRouteBinding($value)`
-in your model. The function should return the model that belongs to the translated slug `$value`. 
+in your model. The function should return the model that belongs to the translated slug `$value`.
 For example:
 
 ```php

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ The package offers the following:
  - Supports caching & testing
  - Option to hide default locale in url
  - Many snippets and helpers (like language selector)
- - Something important
 
 ## Table of Contents
 
@@ -357,31 +356,53 @@ Note that Route Model Binding is supported.
 
 ## Translated Routes
 
-You can adapt your URLs depending on the language you want to show them. For example, http://url/en/about and http://url/es/acerca (acerca is about in spanish) or http://url/en/view/5 and http://url/es/ver/5 (view == ver in spanish) would be redirected to the same controller using the proper filter and setting up the translation files as follows:
+You can adapt your URLs depending on the language you want to show them. For example, http://url/en/about and http://url/es/acerca (acerca is about in spanish) or http://url/en/article/5 and http://url/es/articulo/5 (view == ver in spanish) would be redirected to the same controller using the proper filter and setting up the translation files as follows:
 
 It is necessary that the `localize` middleware in loaded in your `Route::group` middleware (See [installation instruction](#LaravelLocalizationRoutes)).
 
-In the routes file you just have to add the `LaravelLocalizationRoutes` filter and the `LaravelLocalization::transRoute` function to every route you want to translate using the translation key.
+For each language, add a `routes.php` into `resources/lang/**/routes.php` folder.
+The file contains an array with all translatable routes. For example, like this:
 
-Then you have to create the translation files and add there every key you want to translate. I suggest to create a routes.php file inside your `resources/lang/language_abbreviation` folder. For the previous example, I have created two translations files, these two files would look like:
 ```php
+<?php
 // resources/lang/en/routes.php
 return [
 	"about" 	=> 	"about",
-	"view" 		=> 	"view/{id}", //we add a route parameter
+	"article" 		=> 	"article/{article}", //we add a route parameter
 	// other translated routes
 ];
 ```
 ```php
+<?php
 // resources/lang/es/routes.php
 return [
 	"about" 	=> 	"acerca",
-	"view" 		=> 	"ver/{id}", //we add a route parameter
+	"article" 		=> 	"articulo/{article}", //we add a route parameter
 	// other translated routes
 ];
 ```
 
-Once files are saved, you can access to http://url/en/about , http://url/es/acerca , http://url/en/view/5 and http://url/es/ver/5 without any problem.
+You may add the routes to in `routes/web.php` like this:
+
+```php
+Route::group(['prefix' => LaravelLocalization::setLocale(),
+              'middleware' => [ 'localize' ]], function () {
+
+    Route::get(LaravelLocalization::transRoute('routes.about'), function () {
+        return view('about');
+    });
+
+    Route::get(LaravelLocalization::transRoute('routes.article'), function (\App\Article $article) {
+        return $article;
+    });
+
+    //,...
+});
+```
+
+
+
+Once files are saved, you can access to http://url/en/about , http://url/es/acerca , http://url/en/article/5 and http://url/es/articulo/5 without any problem.
 
 ### Translatable route parameters
 

--- a/README.md
+++ b/README.md
@@ -356,10 +356,10 @@ Note that Route Model Binding is supported.
 
 ## Translated Routes
 
-You can translate your URL. For example, http://url/en/about and http://url/es/acerca (acerca is about in spanish)
-or http://url/en/article/5 and http://url/es/articulo/5 (article is articulo in spanish) would be redirected to the same controller using the proper filter and setting up the translation files as follows:
+You may translate your routes. For example, http://url/en/about and http://url/es/acerca (acerca is about in spanish)
+or http://url/en/article/important-article and http://url/es/articulo/important-article (article is articulo in spanish) would be redirected to the same controller/view as follows:
 
-It is necessary that the `localize` middleware in loaded in your `Route::group` middleware (See [installation instruction](#LaravelLocalizationRoutes)).
+It is necessary that at least the `localize` middleware in loaded in your `Route::group` middleware (See [installation instruction](#LaravelLocalizationRoutes)).
 
 For each language, add a `routes.php` into `resources/lang/**/routes.php` folder.
 The file contains an array with all translatable routes. For example, like this:
@@ -369,8 +369,7 @@ The file contains an array with all translatable routes. For example, like this:
 // resources/lang/en/routes.php
 return [
 	"about" 	=> 	"about",
-	"article" 		=> 	"article/{article}", //we add a route parameter
-	// other translated routes
+	"article"   => 	"article/{article}",
 ];
 ```
 ```php
@@ -378,12 +377,11 @@ return [
 // resources/lang/es/routes.php
 return [
 	"about" 	=> 	"acerca",
-	"article" 		=> 	"articulo/{article}", //we add a route parameter
-	// other translated routes
+	"article" 	=> 	"articulo/{article}",
 ];
 ```
 
-You may add the routes to in `routes/web.php` like this:
+You may add the routes in `routes/web.php` like this:
 
 ```php
 Route::group(['prefix' => LaravelLocalization::setLocale(),
@@ -401,23 +399,31 @@ Route::group(['prefix' => LaravelLocalization::setLocale(),
 });
 ```
 
-
-
-Once files are saved, you can access to http://url/en/about , http://url/es/acerca , http://url/en/article/5 and http://url/es/articulo/5 without any problem.
+Once files are saved, you can access http://url/en/about , http://url/es/acerca , http://url/en/article/important-article and http://url/es/articulo/important-article without any problem.
 
 ### Translatable route parameters
 
-You may use translatable slugs for your model, for example like this:
+Maybe you noticed in the previous example the English slug in the Spanish url:
+
+    http://url/es/articulo/important-article
+
+It is possible to have translated slugs, for example like this:
 
     http://url/en/article/important-change
     http://url/es/articulo/cambio-importante
 
-For this, your model needs to implement `\Mcamara\LaravelLocalization\Interfaces\LocalizedUrlRoutable`.
-The function `getLocalizedRouteKey($locale)` must return for a given locale the translated slug.
-This is necessary so that your urls will be correctly [localized](#localized-urls).
+However, in order to do this, each article must have many slugs (one for each locale).
+Its up to you how you want to implement this relation. The only requirements for translatable route parameters is that the relevant model implements the interface `LocalizedUrlRoutable` and adjusts the route-model-binding.
 
-Also, to use [route-model-binding](https://laravel.com/docs/routing#route-model-binding), you should overwrite the function `resolveRouteBinding($slug)`
-in your model. The function should return the model that belongs to the translated slug `$slug`.
+#### Implementing LocalizedUrlRoutable
+
+To implement `\Mcamara\LaravelLocalization\Interfaces\LocalizedUrlRoutable`,
+one has to create the function `getLocalizedRouteKey($locale)`, which must return for a given locale the translated slug. For example, in the above example, `getLocalizedRouteKey('en')` should return `important-change` and `getLocalizedRouteKey('es')` should return `cambio-importante`.
+
+#### Route Model Binding
+
+To use [route-model-binding](https://laravel.com/docs/routing#route-model-binding), one  should overwrite the function `resolveRouteBinding($slug)`
+in the model. The function should return the model that belongs to the translated slug `$slug`.
 For example:
 
 ```php

--- a/README.md
+++ b/README.md
@@ -368,16 +368,16 @@ The file contains an array with all translatable routes. For example, like this:
 <?php
 // resources/lang/en/routes.php
 return [
-	"about" 	=> 	"about",
-	"article"   => 	"article/{article}",
+  "about"   =>  "about",
+  "article" =>  "article/{article}",
 ];
 ```
 ```php
 <?php
 // resources/lang/es/routes.php
 return [
-	"about" 	=> 	"acerca",
-	"article" 	=> 	"articulo/{article}",
+  "about"   =>  "acerca",
+  "article"	=>  "articulo/{article}",
 ];
 ```
 


### PR DESCRIPTION
It seems that the section for translatable urls were not self-explanatory enough. 

The latest issues were raised about this functionality, see #672, #681, #682

Improved examples, improved structure, and also added a tutorial video.