### PR TITLE
Preserve "locale" cookie value on redirect to localized URL

### DIFF
--- a/src/Mcamara/LaravelLocalization/Middleware/LocaleCookieRedirect.php
+++ b/src/Mcamara/LaravelLocalization/Middleware/LocaleCookieRedirect.php
@@ -56,7 +56,7 @@ class LocaleCookieRedirect extends LaravelLocalizationMiddlewareBase
             $redirection = app('laravellocalization')->getLocalizedURL($locale);
             $redirectResponse = new RedirectResponse($redirection, 302, ['Vary' => 'Accept-Language']);
 
-            return $redirectResponse->withCookie(cookie()->forever('locale', $params[0]));
+            return $redirectResponse->withCookie(cookie()->forever('locale', $locale));
         }
 
         return $next($request);


### PR DESCRIPTION
Set the detected locale instead of the first URL path segment to the "locale" cookie during redirect caused by `LocaleCookieRedirect`

Fixes #714 