### PR TITLE
#761 Handle locales mapping when loading caches routes

### DIFF
--- a/src/Mcamara/LaravelLocalization/Traits/LoadsTranslatedCachedRoutes.php
+++ b/src/Mcamara/LaravelLocalization/Traits/LoadsTranslatedCachedRoutes.php
@@ -24,7 +24,9 @@ trait LoadsTranslatedCachedRoutes
 
         // compute $locale from url.
         // It is null if url does not contain locale.
-        $locale = $localization->setLocale();
+        $locale = $localization->getInversedLocaleFromMapping(
+            $localization->setLocale()
+        );
 
         $localeKeys = $localization->getSupportedLanguagesKeys();
 


### PR DESCRIPTION
This fix intend to solve issues when caching routes with locales mapping.

The current locale is mapped with configuration so that it will be mapped back if there's a match.