### PR TITLE
Extract should redirect logic to method on base middleware

### DIFF
--- a/src/Mcamara/LaravelLocalization/Middleware/LaravelLocalizationMiddlewareBase.php
+++ b/src/Mcamara/LaravelLocalization/Middleware/LaravelLocalizationMiddlewareBase.php
@@ -33,4 +33,16 @@ class LaravelLocalizationMiddlewareBase
 
         return false;
     }
+
+    protected function shouldRedirectToLocalizedUrl($locale): bool
+    {
+        return app('laravellocalization')->checkLocaleInSupportedLocales($locale) &&
+            ! app('laravellocalization')->isHiddenDefault($locale);
+    }
+
+    protected function shouldRedirectToNonLocalizedUrl($locale): bool
+    {
+        return app('laravellocalization')->checkLocaleInSupportedLocales($locale) &&
+            app('laravellocalization')->isHiddenDefault($locale);
+    }
 }

--- a/src/Mcamara/LaravelLocalization/Middleware/LaravelLocalizationRedirectFilter.php
+++ b/src/Mcamara/LaravelLocalization/Middleware/LaravelLocalizationRedirectFilter.php
@@ -30,15 +30,13 @@ class LaravelLocalizationRedirectFilter extends LaravelLocalizationMiddlewareBas
         if (\count($params) > 0) {
             $locale = $params[0];
 
-            if (app('laravellocalization')->checkLocaleInSupportedLocales($locale)) {
-                if (app('laravellocalization')->isHiddenDefault($locale)) {
-                    $redirection = app('laravellocalization')->getNonLocalizedURL();
+            if ($this->shouldRedirectToNonLocalizedUrl($locale)) {
+                $redirection = app('laravellocalization')->getNonLocalizedURL();
 
-                    // Save any flashed data for redirect
-                    app('session')->reflash();
+                // Save any flashed data for redirect
+                app('session')->reflash();
 
-                    return new RedirectResponse($redirection, 302, ['Vary' => 'Accept-Language']);
-                }
+                return new RedirectResponse($redirection, 302, ['Vary' => 'Accept-Language']);
             }
         }
 

--- a/src/Mcamara/LaravelLocalization/Middleware/LocaleCookieRedirect.php
+++ b/src/Mcamara/LaravelLocalization/Middleware/LocaleCookieRedirect.php
@@ -48,11 +48,7 @@ class LocaleCookieRedirect extends LaravelLocalizationMiddlewareBase
             $locale = app('laravellocalization')->getCurrentLocale();
         }
 
-        if (
-            $locale &&
-            app('laravellocalization')->checkLocaleInSupportedLocales($locale) &&
-            !(app('laravellocalization')->isHiddenDefault($locale))
-        ) {
+        if ($this->shouldRedirectToLocalizedUrl($locale)) {
             $redirection = app('laravellocalization')->getLocalizedURL($locale);
             $redirectResponse = new RedirectResponse($redirection, 302, ['Vary' => 'Accept-Language']);
 

--- a/src/Mcamara/LaravelLocalization/Middleware/LocaleSessionRedirect.php
+++ b/src/Mcamara/LaravelLocalization/Middleware/LocaleSessionRedirect.php
@@ -50,11 +50,7 @@ class LocaleSessionRedirect extends LaravelLocalizationMiddlewareBase
             $locale = app('laravellocalization')->getCurrentLocale();
         }
 
-        if (
-            $locale &&
-            app('laravellocalization')->checkLocaleInSupportedLocales($locale) &&
-            !(app('laravellocalization')->isHiddenDefault($locale))
-        ) {
+        if ($this->shouldRedirectToLocalizedUrl($locale)) {
             app('session')->reflash();
             $redirection = app('laravellocalization')->getLocalizedURL($locale);
 


### PR DESCRIPTION
In some cases the `hideDefaultLocaleInURL` isn't a static value and reading the config wouldn't suffice. For example:

- Domain `example.nl`
  - Has locales:
    - `nl`
  - Default locale: `nl`
  - Hide default locale: `true`
- Domain `example.be`
  - Has locales:
    - `fr`
    - `nl`
  - Default locale: `fr`
  - Hide default locale: `false`

This PR extracts the logic to determine whether the request should be redirected to the (non-) localized URL or not to a method on the base middleware class, so a user could write their own middleware, but are able to extend the package middleware; they only need to overwrite the `shouldRedirectToLocalizedUrl` and `shouldRedirectToNonLocalizedUrl` methods.

What do you think?