### PR TITLE
fix: Passing null to parameter #1 in parse_url()

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -270,9 +270,6 @@ class LaravelLocalization
             $attributes = $this->extractAttributes($url, $locale);
         }
 
-        $urlQuery = parse_url($url, PHP_URL_QUERY);
-        $urlQuery = $urlQuery ? '?'.$urlQuery : '';
-
         if (empty($url)) {
             $url = $this->request->fullUrl();
             $urlQuery = parse_url($url, PHP_URL_QUERY);
@@ -282,6 +279,9 @@ class LaravelLocalization
                 return $this->getURLFromRouteNameTranslated($locale, $this->routeName, $attributes, $forceDefaultLocation) . $urlQuery;
             }
         } else {
+            $urlQuery = parse_url($url, PHP_URL_QUERY);
+            $urlQuery = $urlQuery ? '?'.$urlQuery : '';
+
             $url = $this->url->to($url);
         }
 


### PR DESCRIPTION
This PR fixes the below warning when running on PHP 8.1:

```
parse_url(): Passing null to parameter #1 ($url) of type string is deprecated in .../vendor/mcamara/laravel-localization/src/Mcamara/LaravelLocalization/LaravelLocalization.php on line 273
```