### PR TITLE
fix: str_replace(): Passing null warning

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -645,7 +645,10 @@ class LaravelLocalization
             elseif ($value instanceOf UrlRoutable) {
                 $value = $value->getRouteKey();
             }
-            $route = str_replace(array('{'.$key.'}', '{'.$key.'?}'), $value, $route);
+
+            if ($value !== null) {
+                $route = str_replace(array('{'.$key.'}', '{'.$key.'?}'), $value, $route);
+            }        
         }
 
         // delete empty optional arguments that are not in the $attributes array


### PR DESCRIPTION
This PR resolves #822 

It's an issue that occurred since PHP 8 (or 8.1). A minor inconvenience seeing all warning logs for an easy fix.