### PR TITLE
hidden prefix redirection when locale cookie exist issue fixed

### DIFF
--- a/src/Mcamara/LaravelLocalization/Middleware/LaravelLocalizationRedirectFilter.php
+++ b/src/Mcamara/LaravelLocalization/Middleware/LaravelLocalizationRedirectFilter.php
@@ -33,11 +33,15 @@ class LaravelLocalizationRedirectFilter extends LaravelLocalizationMiddlewareBas
             if (app('laravellocalization')->checkLocaleInSupportedLocales($locale)) {
                 if (app('laravellocalization')->isHiddenDefault($locale)) {
                     $redirection = app('laravellocalization')->getNonLocalizedURL();
+                    $redirectResponse = new RedirectResponse($redirection, 301, ['Pragma' => 'no-cache']);
 
                     // Save any flashed data for redirect
                     app('session')->reflash();
 
-                    return new RedirectResponse($redirection, 302, ['Vary' => 'Accept-Language']);
+                    if ($request->hasCookie('locale') && $request->cookie('locale') != $locale)
+                        $redirectResponse->withCookie(cookie()->forever('locale', $locale));
+
+                    return $redirectResponse;
                 }
             }
         }


### PR DESCRIPTION
When "hideDefaultLocaleInURL" is true and we also want to use LocaleCookieRedirect middleware there is an issue happen. If users change their language with visiting prefixed route other than default locale (ex. https://example.com/es/foo-bar) then they want to revert again to the default language with visiting default prefixed (ex. https://example.com/en/foo-bar - en is default) route, LocaleCookieRedirect middleware redirecting them to "https://example.com/es/foo-bar" because of locale cookie (it's still "es"). So I added some rows to LaravelLocalizationRedirectFilter middleware for locale cookie update.

Also I change the http status code from 302 to 301 for this redirection because of this both page exactly the same (for SEO) and add "Pragma: no-cache" header for prevent browser cache issues.