### PR TITLE
Add an example with attributes for getURLFromRouteNameTranslated

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,13 @@ Returns a route, [localized](#translated-routes) to the desired locale. If the t
 // Returns /es/acerca
 {{ LaravelLocalization::getURLFromRouteNameTranslated('es', 'routes.about') }}
 ```
+**Example of a localized link using routes with attributes**
+
+```php
+// An array of attributes can be provided.
+// Returns /en/archive/ghosts, /fr/archive/fantômes, /pt/arquivo/fantasmas, etc.
+<a href="{{ LaravelLocalization::getURLFromRouteNameTranslated( App::currentLocale(), 'routes.archive', array('category' => 'ghosts')) }}">Ghost Stories</a>
+```
 
 
 ### Get Supported Locales


### PR DESCRIPTION
This appears to be the most direct way to make links within a website that leverage the `routes.php` files. The lack of documentation for the use of the attributes took me way to long to look up. So here I am providing a simple addition to the documentation to help others (and myself) in the future.