### PR TITLE
Support contextual binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2.0.0
+- Support [contextual binding](https://laravel.com/docs/container#contextual-binding) ([#879](https://github.com/mcamara/laravel-localization/pull/879))
+
+For guidance on the upgrade process, please refer to the [UPGRADING.md](/UPGRADING.md) file.
+
 ### 1.4.0
 - Added compatibility with Laravel 6
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,41 @@
+## From v1 to v2
+This package now uses [dependency injection](https://laravel.com/docs/container#introduction) to retrieve dependencies from the container.
+
+This modification is a breaking change, especially if you had made extensions to the `__construct` method within the `Mcamara\LaravelLocalization\LaravelLocalization` class.
+You may now use depdency injection in your own implementation and forward the dependencies to the parent constructor.
+```php
+use Mcamara\LaravelLocalization\LaravelLocalization;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Routing\UrlGenerator;
+use Illuminate\Contracts\Translation\Translator;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Router;
+
+class MyLaravelLocalization extends LaravelLocalization
+{
+    public function __construct(
+        mixed $myCustomVariable,
+        Application $app,
+        ConfigRepository $configRepository,
+        Translator $translator,
+        Router $router,
+        Request $request,
+        UrlGenerator $url
+    ) {
+        parent::__construct($app, $configRepository, $translator, $router, $request, $url);
+    }
+}
+```
+
+If your previous approach involved overriding the `LaravelLocalization` singleton in the container and generating a new instance of your custom implementation, there's now a more straightforward method for binding. This will automatically inject the correct dependencies for you.
+```diff
+use Mcamara\LaravelLocalization\LaravelLocalization;
+
+-$this->app->singleton(LaravelLocalization::class, function () {
+-    return new MyLaravelLocalization();
+-});
++$this->app->singleton(LaravelLocalization::class, MyLaravelLocalization::class);
+```
+
+For more information, please see the following PR [#879](https://github.com/mcamara/laravel-localization/pull/879/files)

--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -2,8 +2,13 @@
 
 namespace Mcamara\LaravelLocalization;
 
-use Illuminate\Config\Repository;
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Routing\UrlGenerator;
 use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\Contracts\Translation\Translator;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Router;
 use Illuminate\Support\Str;
 use Illuminate\Support\Env;
 use Mcamara\LaravelLocalization\Exceptions\SupportedLocalesNotDefined;
@@ -19,21 +24,14 @@ class LaravelLocalization
     /**
      * Config repository.
      *
-     * @var \Illuminate\Config\Repository
+     * @var \Illuminate\Contracts\Config\Repository
      */
     protected $configRepository;
 
     /**
-     * Illuminate view Factory.
-     *
-     * @var \Illuminate\View\Factory
-     */
-    protected $view;
-
-    /**
      * Illuminate translator class.
      *
-     * @var \Illuminate\Translation\Translator
+     * @var \Illuminate\Contracts\Translation\Translator
      */
     protected $translator;
 
@@ -47,21 +45,21 @@ class LaravelLocalization
     /**
      * Illuminate request class.
      *
-     * @var \Illuminate\Routing\Request
+     * @var \Illuminate\Http\Request
      */
     protected $request;
 
     /**
      * Illuminate url class.
      *
-     * @var \Illuminate\Routing\UrlGenerator
+     * @var \Illuminate\Contracts\Routing\UrlGenerator
      */
     protected $url;
 
     /**
      * Illuminate request class.
      *
-     * @var Illuminate\Foundation\Application
+     * @var \Illuminate\Contracts\Foundation\Application
      */
     protected $app;
 
@@ -126,16 +124,20 @@ class LaravelLocalization
      *
      * @throws UnsupportedLocaleException
      */
-    public function __construct()
-    {
-        $this->app = app();
-
-        $this->configRepository = $this->app['config'];
-        $this->view = $this->app['view'];
-        $this->translator = $this->app['translator'];
-        $this->router = $this->app['router'];
-        $this->request = $this->app['request'];
-        $this->url = $this->app['url'];
+    public function __construct(
+        Application $app,
+        ConfigRepository $configRepository,
+        Translator $translator,
+        Router $router,
+        Request $request,
+        UrlGenerator $url
+    ) {
+        $this->app = $app;
+        $this->configRepository = $configRepository;
+        $this->translator = $translator;
+        $this->router = $router;
+        $this->request = $request;
+        $this->url = $url;
 
         // set default locale
         $this->defaultLocale = $this->configRepository->get('app.locale');
@@ -786,7 +788,7 @@ class LaravelLocalization
     /**
      * Returns the config repository for this instance.
      *
-     * @return Repository Configuration repository
+     * @return \Illuminate\Contracts\Config\Repository Configuration repository
      */
     public function getConfigRepository()
     {

--- a/src/Mcamara/LaravelLocalization/LaravelLocalizationServiceProvider.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalizationServiceProvider.php
@@ -51,9 +51,7 @@ class LaravelLocalizationServiceProvider extends ServiceProvider
      */
     protected function registerBindings()
     {
-        $this->app->singleton(LaravelLocalization::class, function () {
-            return new LaravelLocalization();
-        });
+        $this->app->singleton(LaravelLocalization::class);
 
         $this->app->alias(LaravelLocalization::class, 'laravellocalization');
     }

--- a/tests/LocalizerTests.php
+++ b/tests/LocalizerTests.php
@@ -1,6 +1,6 @@
 <?php
 
-use Illuminate\Routing\Route;
+use Mcamara\LaravelLocalization\LaravelLocalization;
 
 class LocalizerTests extends \Orchestra\Testbench\BrowserKit\TestCase
 {
@@ -328,10 +328,10 @@ class LocalizerTests extends \Orchestra\Testbench\BrowserKit\TestCase
     public function testGetLocalizedURLWithQueryStringAndhideDefaultLocaleInURL()
     {
         app('config')->set('laravellocalization.hideDefaultLocaleInURL', true);
-         app()['request'] = $this->createRequest(
+        $request = $this->createRequest(
             $uri = 'en/about?q=2'
         );
-        $laravelLocalization = new \Mcamara\LaravelLocalization\LaravelLocalization();
+        $laravelLocalization = app(LaravelLocalization::class, ['request' => $request]);
         $laravelLocalization->transRoute('LaravelLocalization::routes.about');
 
         $this->assertEquals(
@@ -342,10 +342,10 @@ class LocalizerTests extends \Orchestra\Testbench\BrowserKit\TestCase
 
     public function testGetLocalizedURLWithQueryStringAndNotTranslatedRoute()
     {
-         app()['request'] = $this->createRequest(
+        $request = $this->createRequest(
             $uri = 'en/about?q=2'
         );
-        $laravelLocalization = new \Mcamara\LaravelLocalization\LaravelLocalization();
+        $laravelLocalization = app(LaravelLocalization::class, ['request' => $request]);
 
         $this->assertEquals(
             $this->test_url . 'en/about?q=2',


### PR DESCRIPTION
Hi, this PR adds support for [contextual binding](https://laravel.com/docs/10.x/container#contextual-binding) in Laravel.

This comes in handy when you want to inject a different implementation into the `LaravelLocalization` class.

A quick example: We have extended Laravel's translations loader to support loading translations from the database.
We have done so by overwriting the `app('translator')` in the container.
However, to improve performance we would like to only load translations from the filesystem when using this package.
Before this PR, there was no way to tell Laravel that the `LaravelLocalization` class can only use the file loader.
After this PR, we can now tell Laravel to inject the file loader instance when it is requested by the `LaravelLocalization` class:

```php
        $this
            ->app
            ->when(LaravelLocalization::class)
            ->needs(Translator::class)
            ->give(function (Application $app) {
                $loader = new FileLoader($app['files'], [__DIR__.'/lang', $app['path.lang']]);

                return new Translator($loader, $app->getLocale());
            });
```

**What has been changed in this PR?**
- The `LaravelLocalization` class now uses [depedency injection](https://laravel.com/docs/10.x/container#introduction) to retrieve instances from the container. This looks like a breaking change since the constructor has been altered.
- The `$view` class property has been removed, since it was not used anywhere.

**What tests have been changed in this PR?**
- All places where a new instance of the `LaravelLocalization` class was created has been changed to now retrieve the instance from the container instead.