### PR TITLE
Missing null on PHPDoc block return

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -151,7 +151,7 @@ class LaravelLocalization
      *
      * @param string $locale Locale to set the App to (optional)
      *
-     * @return string Returns locale (if route has any) or null (if route does not have a locale)
+     * @return string|null Returns locale (if route has any) or null (if route does not have a locale)
      */
     public function setLocale($locale = null)
     {


### PR DESCRIPTION
I am getting a warning on my Laravel project using PHPStan, because it correctly understands what is being defined on the `@return` in https://github.com/mcamara/laravel-localization/blob/afe2e677f280dfdb19ceebb5f8cfe894fb036c17/src/Mcamara/LaravelLocalization/LaravelLocalization.php#L154.

The description correctly says it may return `null`, but the type is not inferring it so this fixes it.

![image](https://github.com/mcamara/laravel-localization/assets/1213303/9653678d-ad49-486a-96d6-ccfc1eb389a9)
