### PR TITLE
Updated link to appropriate installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ Note that Route Model Binding is supported.
 You may translate your routes. For example, http://url/en/about and http://url/es/acerca (acerca is about in spanish)
 or http://url/en/article/important-article and http://url/es/articulo/important-article (article is articulo in spanish) would be redirected to the same controller/view as follows:
 
-It is necessary that at least the `localize` middleware in loaded in your `Route::group` middleware (See [installation instruction](#LaravelLocalizationRoutes)).
+It is necessary that at least the `localize` middleware in loaded in your `Route::group` middleware (See [installation instruction](#installation)).
 
 For each language, add a `routes.php` into `resources/lang/**/routes.php` folder.
 The file contains an array with all translatable routes. For example, like this:


### PR DESCRIPTION
Link was pointing to `#LaravelLocalizationRoutes` which doesn't exist anymore. This most likely was replaced with `#installation`.