### PR TITLE
Update LaravelLocalization.php

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -647,7 +647,8 @@ class LaravelLocalization
             elseif ($value instanceOf UrlRoutable) {
                 $value = $value->getRouteKey();
             }
-            $route = str_replace(array('{'.$key.'}', '{'.$key.'?}'), $value, $route);
+            if($value)
+                $route = str_replace(array('{'.$key.'}', '{'.$key.'?}'), $value, $route);
         }
 
         // delete empty optional arguments that are not in the $attributes array


### PR DESCRIPTION
check if value is not empty before str_replace because passing null to parameter #2 ($replace) of type array|string is deprecated