### PR TITLE
chore: update PHP and Laravel version requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "orchestra/testbench-browser-kit": "^8.5|^9.0",
-        "phpunit/phpunit": "^10.0"
+        "phpunit/phpunit": "^9.5.10|^10.0"
     },
     "suggest": {
         "ext-intl": "*"

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0",
-        "laravel/framework": "~5.2.0||~5.3.0||~5.4.0||~5.5.0||~5.6.0||~5.7.0||~5.8.0||^6.0||^7.0||^8.0||^9.0|^10.0||^11.0"
+        "php": "^8.2",
+        "laravel/framework": "^10.0|^11.0"
     },
     "require-dev": {
-        "orchestra/testbench-browser-kit": "~3.4|~3.8|~4.0|^7.12|^8.5|^9.0",
-        "phpunit/phpunit": "6.0.*|^8.0|^9.5.10|^10.0"
+        "orchestra/testbench-browser-kit": "^8.5|^9.0",
+        "phpunit/phpunit": "^10.0"
     },
     "suggest": {
         "ext-intl": "*"


### PR DESCRIPTION
Previous (unsupported) versions were kept in the composer.json file. These version constraints are now aligned with what is mentioned in the README and the run-tests action.