### PR TITLE
fix: duplicate route registration in tests

### DIFF
--- a/tests/LaravelLocalizationTest.php
+++ b/tests/LaravelLocalizationTest.php
@@ -134,8 +134,6 @@ final class LaravelLocalizationTest extends TestCase
         app('translator')->load('LaravelLocalization', 'routes', 'en');
 
         app('laravellocalization')->setBaseUrl(self::TEST_URL);
-
-        $this->setRoutes();
     }
 
     public function testSetLocale(): void


### PR DESCRIPTION
A recent change in the Laravel framework (laravel/framework#56920) has caused the `testSetLocale` test of this package to fail.

After some digging, it turns out the test suite was registering routes multiple times. This happens via the `setRoutes` method, which is called in both `refreshApplication` and `getEnvironmentSetUp`.

The recent Laravel change modified how routes are prioritized, meaning the last registered route is no longer guaranteed to be matched first. While the framework update caused this issue to pop up, the underlying problem has existed in this package for some time.

This fixes #943.