### PR TITLE
test: cleanup

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,9 +20,9 @@ jobs:
                   - laravel: 12.*
                     testbench: 10.*
                   - laravel: 11.*
-                    testbench: 9.*
+                    testbench: ^9.9
                   - laravel: 10.*
-                    testbench: 8.*
+                    testbench: ^8.31
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "laravel/framework": "^10.0|^11.0|^12.0"
     },
     "require-dev": {
-        "orchestra/testbench-browser-kit": "^8.5|^9.0|^10.0",
+        "orchestra/testbench": "^8.5|^9.0|^10.0",
         "phpunit/phpunit": "^10.1|^11.0"
     },
     "suggest": {

--- a/tests/LaravelLocalizationTest.php
+++ b/tests/LaravelLocalizationTest.php
@@ -140,18 +140,18 @@ final class LaravelLocalizationTest extends TestCase
 
     public function testSetLocale(): void
     {
-        $this->assertEquals(route('about'), 'http://localhost/about');
+        $this->assertEquals('http://localhost/about', route('about'));
 
         $this->refreshApplication('es');
         $this->assertEquals('es', app('laravellocalization')->setLocale('es'));
         $this->assertEquals('es', app('laravellocalization')->getCurrentLocale());
-        $this->assertEquals(route('about'), 'http://localhost/acerca');
+        $this->assertEquals('http://localhost/acerca', route('about'));
 
         $this->refreshApplication();
 
         $this->assertEquals('en', app('laravellocalization')->setLocale('en'));
 
-        $this->assertEquals(route('about'), 'http://localhost/about');
+        $this->assertEquals('http://localhost/about', route('about'));
 
         $this->assertNull(app('laravellocalization')->setLocale('de'));
         $this->assertEquals('en', app('laravellocalization')->getCurrentLocale());

--- a/tests/LaravelLocalizationTest.php
+++ b/tests/LaravelLocalizationTest.php
@@ -252,19 +252,15 @@ final class LaravelLocalizationTest extends TestCase
 
         app('laravellocalization')->setLocale('en');
 
-        $crawler = $this->call(
-            'GET',
-            self::TEST_URL.'about',
-            [],
-            [],
-            [],
-            ['HTTP_ACCEPT_LANGUAGE' => 'en,es']
+        $response = $this->get(
+            uri: self::TEST_URL.'about',
+            headers: ['HTTP_ACCEPT_LANGUAGE' => 'en,es']
         );
 
-        $this->assertResponseOk();
+        $response->assertStatus(200);
         $this->assertEquals(
             self::TEST_URL.'es/acerca',
-            $crawler->getContent()
+            $response->getContent()
         );
 
         $this->refreshApplication();
@@ -281,19 +277,15 @@ final class LaravelLocalizationTest extends TestCase
             app('laravellocalization')->getLocalizedURL('en', self::TEST_URL.'test?a=1')
         );
 
-        $crawler = $this->call(
-            'GET',
-            app('laravellocalization')->getLocalizedURL('en', self::TEST_URL.'test'),
-            [],
-            [],
-            [],
-            ['HTTP_ACCEPT_LANGUAGE' => 'en,es']
+        $response = $this->get(
+            uri: app('laravellocalization')->getLocalizedURL('en', self::TEST_URL.'test'),
+            headers: ['HTTP_ACCEPT_LANGUAGE' => 'en,es']
         );
 
-        $this->assertResponseOk();
+        $response->assertStatus(200);
         $this->assertEquals(
             'Test text',
-            $crawler->getContent()
+            $response->getContent()
         );
 
         $this->refreshApplication('es');
@@ -370,19 +362,15 @@ final class LaravelLocalizationTest extends TestCase
     }
 
     public function testGetLocalizedUrlForIgnoredUrls(): void {
-        $crawler = $this->call(
-            'GET',
-            self::TEST_URL.'skipped',
-            [],
-            [],
-            [],
-            ['HTTP_ACCEPT_LANGUAGE' => 'en,es']
+        $response = $this->get(
+            uri: self::TEST_URL.'skipped',
+            headers: ['HTTP_ACCEPT_LANGUAGE' => 'en,es']
         );
 
-        $this->assertResponseOk();
+        $response->assertStatus(200);
         $this->assertEquals(
             self::TEST_URL.'skipped',
-            $crawler->getContent()
+            $response->getContent()
         );
     }
 
@@ -881,19 +869,10 @@ final class LaravelLocalizationTest extends TestCase
 
         $savedLocale = 'es';
 
-        $crawler = $this->call(
-            'GET',
-            self::TEST_URL,
-            [],
-            ['locale' => $savedLocale],
-            [],
-            []
-        );
+        $response = $this->withUnencryptedCookie('locale', $savedLocale)->get(self::TEST_URL);
 
-        $this->assertResponseStatus(302);
-        $this->assertRedirectedTo(self::TEST_URL . $savedLocale);
-
-        $localeCookie = $crawler->headers->getCookies()[0];
-        $this->assertEquals($savedLocale, $localeCookie->getValue());
+        $response->assertStatus(302);
+        $response->assertRedirect(self::TEST_URL . $savedLocale);
+        $response->assertPlainCookie('locale', $savedLocale);
     }
 }

--- a/tests/LaravelLocalizationTest.php
+++ b/tests/LaravelLocalizationTest.php
@@ -12,6 +12,8 @@ use Mcamara\LaravelLocalization\Middleware\LaravelLocalizationRedirectFilter;
 use Mcamara\LaravelLocalization\Middleware\LaravelLocalizationRoutes;
 use Mcamara\LaravelLocalization\Middleware\LocaleCookieRedirect;
 
+use function Orchestra\Testbench\refresh_router_lookups;
+
 final class LaravelLocalizationTest extends TestCase
 {
     protected const TEST_URL = 'http://localhost/';
@@ -66,6 +68,8 @@ final class LaravelLocalizationTest extends TestCase
         Route::get('/skipped', function () {
             return Request::url();
         })->name('skipped');
+
+        refresh_router_lookups(Route::getFacadeRoot());
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,7 +4,7 @@ namespace Mcamara\LaravelLocalization\Tests;
 
 use Mcamara\LaravelLocalization\Facades\LaravelLocalization;
 use Mcamara\LaravelLocalization\LaravelLocalizationServiceProvider;
-use Orchestra\Testbench\BrowserKit\TestCase as BaseTestCase;
+use Orchestra\Testbench\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {


### PR DESCRIPTION
This PR refactors the current test-suite to be more up to date with recent standards.
- Use `orchestra/testbench` instead of `orchestra/testbench-browser-kit`. This was originally PR'd in #399 but can now be replaced with the core package.
- Route registration now utilizes the `name` method to assign route names, instead of the old array-syntax.
- Route registration is now more aligned with examples in the README.
- Changed the `assertResponseOk` with `assertStatus(200)`, which improves readability.
- Swapped the order of some `assertEquals` parameters, as `actual` and `expected` were passed the wrong way around.