### PR TITLE
docs: deprecate package in favor of niels-numbers/laravel-localizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@
 [![Open Source Helpers](https://www.codetriage.com/mcamara/laravel-localization/badges/users.svg)](https://www.codetriage.com/mcamara/laravel-localization)
 [![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)
 
+> **This package is no longer actively maintained.**
+>
+> Active development has moved to
+> [**niels-numbers/laravel-localizer**](https://github.com/niels-numbers/laravel-localizer)
+> - a from-scratch rebuild that fixes long-standing issues
+> (`route:cache` compatibility, package-ecosystem conflicts,
+> POST/PUT/DELETE redirect handling) while keeping the same feature set
+> (translated URI paths, hide-default-locale, browser detection) and
+> adding adapters for Ziggy and Wayfinder.
+>
+> New users should start there. Existing users will find the migration
+> straightforward - see the [README](https://github.com/niels-numbers/laravel-localizer#readme).
+
 Easy i18n localization for Laravel, an useful tool to combine with Laravel localization classes.
 
 The package offers the following:

--- a/composer.json
+++ b/composer.json
@@ -51,5 +51,6 @@
         }
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "abandoned": "niels-numbers/laravel-localizer"
 }


### PR DESCRIPTION
Heads-up @mcamara  - pre-built per our LinkedIn DM today.

Two changes:

1. **README**: deprecation note at the top, pointing to [niels-numbers/laravel-localizer](https://github.com/niels-numbers/laravel-localizer/)
2. **composer.json**: standard `abandoned` field - Composer will show users a deprecation warning on `composer install` / `composer update`

The `abandoned` field is the official Composer mechanism to redirect existing users at install time, so it complements the README note nicely.

Wording, tone and placement are all open - feel free to adjust anything you'd like, or merge as-is. No rush from my end. 

If you'd prefer a softer tone (e.g. "Active development has moved to..." instead of "no longer actively maintained"), happy to revise.

Thanks again for the goodwill - much appreciated.

Background: The successor package grew out of #921 and my appraoch to fix it in #934, where I started a v3.x rewrite of this package - but it became clear pretty quickly that the legacy constraints made it easier to start from scratch than to refactor in place. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with deprecation notice and migration guidance, directing users to the successor package featuring a from-scratch rebuild with compatible functionality.

* **Chores**
  * Marked package as abandoned in package metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->