### PR TITLE
chore: upgrade actions/checkout to v6 (Node.js 22)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
## Summary

Upgrades `actions/checkout` from `v4` to `v6` to resolve the Node.js 20 deprecation warning.

Node.js 20 actions are deprecated; `actions/checkout@v6` runs on Node.js 22.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configuration to use the latest build tooling version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->