### PR TITLE
Fix PHP 8.5 deprecation: null used as array offset in locale methods

### DIFF
--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -630,9 +630,13 @@ class LaravelLocalization
      */
     public function checkLocaleInSupportedLocales($locale)
     {
+        if ($locale === null) {
+            return false;
+        }
+
         $inversedLocale = $this->getInversedLocaleFromMapping($locale);
         $locales = $this->getSupportedLocales();
-        if ($locale !== false && $locale !== null && empty($locales[$locale]) && empty($locales[$inversedLocale])) {
+        if ($locale !== false && empty($locales[$locale]) && empty($locales[$inversedLocale])) {
             return false;
         }
 

--- a/src/Mcamara/LaravelLocalization/LaravelLocalization.php
+++ b/src/Mcamara/LaravelLocalization/LaravelLocalization.php
@@ -171,7 +171,7 @@ class LaravelLocalization
 
         $locale = $this->getInversedLocaleFromMapping($locale);
 
-        if (!empty($this->supportedLocales[$locale])) {
+        if (!empty($locale) && !empty($this->supportedLocales[$locale])) {
             $this->currentLocale = $locale;
         } else {
             // if the first segment/locale passed is not valid
@@ -440,6 +440,10 @@ class LaravelLocalization
      */
     public function getLocaleFromMapping($locale)
     {
+        if ($locale === null) {
+            return null;
+        }
+
         return $this->getLocalesMapping()[$locale] ?? $locale;
     }
 
@@ -452,6 +456,10 @@ class LaravelLocalization
      */
     public function getInversedLocaleFromMapping($locale)
     {
+        if ($locale === null) {
+            return null;
+        }
+
         return \array_flip($this->getLocalesMapping())[$locale] ?? $locale;
     }
 
@@ -624,7 +632,7 @@ class LaravelLocalization
     {
         $inversedLocale = $this->getInversedLocaleFromMapping($locale);
         $locales = $this->getSupportedLocales();
-        if ($locale !== false && empty($locales[$locale]) && empty($locales[$inversedLocale])) {
+        if ($locale !== false && $locale !== null && empty($locales[$locale]) && empty($locales[$inversedLocale])) {
             return false;
         }
 

--- a/tests/LaravelLocalizationTest.php
+++ b/tests/LaravelLocalizationTest.php
@@ -881,4 +881,42 @@ final class LaravelLocalizationTest extends TestCase
         $response->assertRedirect(self::TEST_URL . $savedLocale);
         $response->assertPlainCookie('locale', $savedLocale);
     }
+
+    /**
+     * @see https://github.com/mcamara/laravel-localization/issues/953
+     */
+    public function testGetLocaleFromMappingWithNullDoesNotTriggerDeprecation(): void
+    {
+        $this->assertNull(app('laravellocalization')->getLocaleFromMapping(null));
+    }
+
+    /**
+     * @see https://github.com/mcamara/laravel-localization/issues/953
+     */
+    public function testGetInversedLocaleFromMappingWithNullDoesNotTriggerDeprecation(): void
+    {
+        $this->assertNull(app('laravellocalization')->getInversedLocaleFromMapping(null));
+    }
+
+    /**
+     * @see https://github.com/mcamara/laravel-localization/issues/953
+     */
+    public function testSetLocaleWithNullSegmentAndNoForcedLocaleDoesNotTriggerDeprecation(): void
+    {
+        // Simulate a request with no locale segment (e.g. hitting the root URL)
+        $this->refreshApplication();
+
+        $result = app('laravellocalization')->setLocale(null);
+
+        // Should return null since no valid locale was found
+        $this->assertNull($result);
+    }
+
+    /**
+     * @see https://github.com/mcamara/laravel-localization/issues/953
+     */
+    public function testCheckLocaleInSupportedLocalesWithNullDoesNotTriggerDeprecation(): void
+    {
+        $this->assertFalse(app('laravellocalization')->checkLocaleInSupportedLocales(null));
+    }
 }


### PR DESCRIPTION
## Description

Fixes #953

In PHP 8.5, using `null` as an array offset is deprecated. This PR resolves all occurrences in `LaravelLocalization.php` where `$locale` can be `null` (e.g., when `request->segment(1)` and `getForcedLocale()` both return `null`).

## Changes

- **`getLocaleFromMapping()`** — return `null` early when `$locale === null`
- **`getInversedLocaleFromMapping()`** — return `null` early when `$locale === null`
- **`setLocale()`** — add `!empty($locale) &&` guard before `$this->supportedLocales[$locale]` access
- **`checkLocaleInSupportedLocales()`** — add `$locale !== null` to condition guarding `$locales[$locale]` access

## Testing

All 138 existing tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of `null` locale inputs across locale mapping and validation.
  - Prevented invalid locale lookups and unintended conversions when locale values are missing.
  - Ensured locale mapping and checks return `null`/`false` appropriately instead of attempting lookups.
  - Added coverage to confirm `null` inputs no longer trigger deprecation warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->