### PR TITLE
Fix: RouteTranslationsCacheCommand hijacks route:cache instead of registering as route:trans:cache

### DIFF
--- a/src/Mcamara/LaravelLocalization/Commands/RouteTranslationsCacheCommand.php
+++ b/src/Mcamara/LaravelLocalization/Commands/RouteTranslationsCacheCommand.php
@@ -17,6 +17,15 @@ class RouteTranslationsCacheCommand extends RouteCacheCommand
     protected $name = 'route:trans:cache';
 
     /**
+     * The parent RouteCacheCommand declares `$signature = 'route:cache'`. Illuminate\Console\Command
+     * checks `$signature` before `$name`, so without overriding it here this command silently
+     * registers as `route:cache` instead of `route:trans:cache`, hijacking Laravel's native command.
+     *
+     * @var string
+     */
+    protected $signature = 'route:trans:cache';
+
+    /**
      * @var string
      */
     protected $description = 'Create a route cache file for faster route registration for all locales';


### PR DESCRIPTION
**Describe the bug**

`RouteTranslationsCacheCommand` extends `Illuminate\Foundation\Console\RouteCacheCommand` and only overrides `$name = 'route:trans:cache'`. It doesn't override `$signature`.

`Illuminate\Console\Command::__construct()` checks `$signature` *before* `$name`:

```php
if (isset($this->signature)) {
    $this->configureUsingFluentDefinition();   // uses inherited 'route:cache'
} else {
    parent::__construct($this->name);          // never reached
}
```

Since `RouteTranslationsCacheCommand` doesn't declare its own `$signature`, it inherits `$signature = 'route:cache'` from the parent `RouteCacheCommand`. As a result the command registers itself under the name `route:cache` instead of `route:trans:cache` — silently hijacking Laravel's native route-cache command.

**To Reproduce**

1. Install `mcamara/laravel-localization` on a Laravel 11+ app.
2. Run `php artisan list | grep route:`
3. See that `route:trans:cache` is missing from the list, and `route:cache`'s description now reads "Create a route cache file for faster route registration for all locales" (the package's description, not Laravel's native "...for faster route registration").
4. Run `php artisan route:trans:cache` directly.
5. See error.

**Expected behavior**

- `php artisan route:trans:cache` should run the package's locale-aware route caching.
- `php artisan route:cache` should remain Laravel's native command, untouched.

Instead:
- `php artisan route:trans:cache` → `Command "route:trans:cache" is not defined.`
- `php artisan route:cache` silently runs the package's locale-aware handler instead of Laravel's native one.
- `php artisan optimize` (which calls `route:cache` by name internally, see `Illuminate\Foundation\Console\OptimizeCommand::getOptimizeTasks()`) picks up the hijacked version too, without anyone asking for it.

**More info:**
- Laravel version: 13.x
- laravel-localization version: v2.4.1
- Middleware used in `Route::groups`: `localize` (`LaravelLocalizationRoutes`), `localeViewPath` (`LaravelLocalizationViewPath`), `localizationRedirect` (`LaravelLocalizationRedirectFilter`)
- Relevant config:
  ```php
  'supportedLocales' => [
      'en' => ['name' => 'English', 'script' => 'Latn', 'native' => 'english', 'regional' => 'en_GB'],
      'es' => ['name' => 'Spanish', 'script' => 'Latn', 'native' => 'español', 'regional' => 'es_ES'],
      'fr' => ['name' => 'French', 'script' => 'Latn', 'native' => 'français', 'regional' => 'fr_FR'],
  ],
  'useAcceptLanguageHeader' => false,
  'hideDefaultLocaleInURL' => true,
  ```
- Minimal steps to reproduce on a clean Laravel installation:
  1. `composer create-project laravel/laravel example-app`
  2. `composer require mcamara/laravel-localization`
  3. `php artisan vendor:publish --provider="Mcamara\LaravelLocalization\LaravelLocalizationServiceProvider"`
  4. `php artisan list | grep route:` — no `route:trans:cache`, and `route:cache`'s description is the package's, not Laravel's.
  5. `php artisan route:trans:cache` → `Command "route:trans:cache" is not defined.`

**Additional context**

The fix is a one-line addition to `src/Mcamara/LaravelLocalization/Commands/RouteTranslationsCacheCommand.php`:

```php
protected $signature = 'route:trans:cache';
```

(mirrors what `RouteTranslationsClearCommand` and `RouteTranslationsListCommand` already do correctly — neither of those extends a Laravel command class with its own `$signature`, so neither is affected.)

Worth noting this also means anyone currently running plain `php artisan optimize` in their deploy pipeline is unknowingly getting the package's per-locale route caching instead of Laravel's native single-file cache — works by accident today, but is fragile and will silently change behavior again whenever this gets fixed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the route translation cache command registration.
  - The command now uses the dedicated `route:trans:cache` command instead of conflicting with Laravel’s `route:cache`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->