### PR TITLE
Fix: RouteTranslationsListCommand hijacks route:list on Laravel 13.24+

### DIFF
--- a/src/Mcamara/LaravelLocalization/Commands/RouteTranslationsListCommand.php
+++ b/src/Mcamara/LaravelLocalization/Commands/RouteTranslationsListCommand.php
@@ -6,6 +6,7 @@ use Mcamara\LaravelLocalization\LaravelLocalization;
 use Mcamara\LaravelLocalization\Traits\TranslatedRouteCommandContext;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Console\RouteListCommand;
+use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputArgument;
 
 class RouteTranslationsListCommand extends RouteListCommand
@@ -22,6 +23,25 @@ class RouteTranslationsListCommand extends RouteListCommand
      */
     protected $description = 'List all registered routes for specific locales';
 
+
+    /**
+     * Configure the console command using a fluent definition.
+     *
+     * Laravel 13.24 moved RouteListCommand to a `$signature`, which takes precedence over
+     * `$name`, so without this the command registers itself as `route:list`. Rewriting the
+     * inherited signature keeps the parent's options instead of restating them; `locale`
+     * moves in here because `getArguments()` is not consulted on this path.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function configureUsingFluentDefinition()
+    {
+        $this->signature = Str::replaceFirst('route:list', $this->name, $this->signature)
+            . ' {locale : The locale to list routes for.}';
+
+        parent::configureUsingFluentDefinition();
+    }
 
     /**
      * Execute the console command.

--- a/tests/CommandRegistrationTest.php
+++ b/tests/CommandRegistrationTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Mcamara\LaravelLocalization\Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Console\RouteCacheCommand;
+use Illuminate\Foundation\Console\RouteListCommand;
+use Mcamara\LaravelLocalization\Commands\RouteTranslationsCacheCommand;
+use Mcamara\LaravelLocalization\Commands\RouteTranslationsClearCommand;
+use Mcamara\LaravelLocalization\Commands\RouteTranslationsListCommand;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class CommandRegistrationTest extends TestCase
+{
+    public static function packageCommandDataProvider(): array
+    {
+        return [
+            'cache' => ['route:trans:cache', RouteTranslationsCacheCommand::class],
+            'clear' => ['route:trans:clear', RouteTranslationsClearCommand::class],
+            'list' => ['route:trans:list', RouteTranslationsListCommand::class],
+        ];
+    }
+
+    #[DataProvider('packageCommandDataProvider')]
+    public function testCommandIsRegisteredUnderItsOwnName(string $name, string $expectedClass): void
+    {
+        $commands = $this->app->make(Kernel::class)->all();
+
+        $this->assertArrayHasKey($name, $commands, "Command '{$name}' is not registered.");
+        $this->assertInstanceOf($expectedClass, $commands[$name]);
+    }
+
+    public static function nativeCommandDataProvider(): array
+    {
+        return [
+            'route:cache' => ['route:cache', RouteCacheCommand::class],
+            'route:list' => ['route:list', RouteListCommand::class],
+        ];
+    }
+
+    /**
+     * The package's commands extend Laravel's. Asserting on the exact class rather
+     * than with assertInstanceOf is deliberate: a hijacking subclass would satisfy
+     * assertInstanceOf and the regression would go unnoticed.
+     */
+    #[DataProvider('nativeCommandDataProvider')]
+    public function testLaravelNativeCommandIsNotHijacked(string $name, string $expectedClass): void
+    {
+        $commands = $this->app->make(Kernel::class)->all();
+
+        $this->assertArrayHasKey($name, $commands, "Command '{$name}' is not registered.");
+        $this->assertSame($expectedClass, $commands[$name]::class);
+    }
+
+    public function testTranslatedRouteListCommandKeepsTheLocaleArgumentAndParentOptions(): void
+    {
+        $definition = $this->app->make(Kernel::class)->all()['route:trans:list']->getDefinition();
+
+        $this->assertTrue($definition->hasArgument('locale'));
+        $this->assertTrue($definition->getArgument('locale')->isRequired());
+
+        foreach (['json', 'method', 'name', 'path', 'except-vendor', 'only-vendor'] as $option) {
+            $this->assertTrue($definition->hasOption($option), "Option '--{$option}' is missing.");
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/mcamara/laravel-localization/issues/963
Closes https://github.com/mcamara/laravel-localization/issues/964

**Describe the bug**

`RouteTranslationsListCommand` extends `Illuminate\Foundation\Console\RouteListCommand` and only overrides `$name = 'route:trans:list'`.

Laravel 13.24 consolidated `RouteListCommand` from `$name` + `getArguments()`/`getOptions()` into a single `$signature` (laravel/framework#60926). `Illuminate\Console\Command::__construct()` checks `$signature` *before* `$name`:

```php
if (isset($this->signature)) {
    $this->configureUsingFluentDefinition();   // uses the inherited 'route:list'
} else {
    parent::__construct($this->name);          // never reached
}
```

Since the command doesn't declare its own `$signature`, it inherits `route:list …` from the parent and registers itself as `route:list`, silently hijacking Laravel's native command.

This is the same bug #961 fixed for `RouteTranslationsCacheCommand`. That PR noted `RouteTranslationsListCommand` was unaffected because its parent had no `$signature` — true when it was written, and Laravel 13.24 changed it.

**To Reproduce**

1. Install the package on Laravel >= 13.24.
2. `php artisan route:list` → `The "locale" argument does not exist.`
3. `php artisan route:trans:list` → `Command "route:trans:list" is not defined.`

**Expected behavior**

- `php artisan route:trans:list <locale>` lists the routes for that locale.
- `php artisan route:cache` and `php artisan route:list` remain Laravel's native commands.

**Fix**

Override `configureUsingFluentDefinition()` and rewrite the inherited signature instead of declaring a new one:

```php
#[\Override]
protected function configureUsingFluentDefinition()
{
    $this->signature = Str::replaceFirst('route:list', $this->name, $this->signature)
        . ' {locale : The locale to list routes for.}';

    parent::configureUsingFluentDefinition();
}
```

Two reasons not to simply declare `protected $signature = 'route:trans:list {locale}'` here, the way #961 did for the cache command:

1. `RouteListCommand` carries a full option list (`--json`, `--method`, `--path`, `--sort`, …). Restating it duplicates something that drifts every time Laravel adds or renames an option.
2. More importantly, declaring `$signature` on the child makes `isset($this->signature)` true on **every** Laravel version, not just 13.24+. That skips `specifyParameters()` on Laravel 11 and 12 — the only thing that reads the parent's `getOptions()`. I measured it on Laravel 12: every option disappears.

Overriding the method instead is version-adaptive, because it is only *called* when the parent declares a `$signature`:

| Laravel | parent style | override called? | result |
| --- | --- | --- | --- |
| 11, 12, ≤ 13.23 | `$name` | no | old path untouched, `getOptions()` still applies |
| ≥ 13.24 | `$signature` | yes | name rewritten, parent's options inherited |

`getArguments()` is kept for the older path; `locale` is appended to the signature because `getArguments()` isn't consulted on the fluent one.

For what it's worth, #961's one-liner is correct where it is — `RouteCacheCommand` declares no arguments or options in v11.55.1, v12.66.0, v13.23.0 or v13.24.0, so nothing is lost. It just isn't transferable to a command that has them, which is worth knowing before the same fix is applied elsewhere.

**Tests**

Adds `tests/CommandRegistrationTest.php`:

- each of the three package commands registers under its own name;
- `route:list` and `route:cache` still resolve to Laravel's own classes. These assert the exact class rather than using `assertInstanceOf`, because the package's commands *are* subclasses — a hijacking command satisfies `assertInstanceOf` and the regression would pass unnoticed;
- `route:trans:list` keeps both the required `locale` argument and the parent's options, which is what catches the option-loss failure mode described above.

Green on PHP 8.2 + Laravel 11, PHP 8.5 + Laravel 12, and PHP 8.5 + Laravel 13.25. Without the `src/` change, on 13.25:

```
Failed asserting that two strings are identical.
-'Illuminate\Foundation\Console\RouteListCommand'
+'Mcamara\LaravelLocalization\Commands\RouteTranslationsListCommand'
```

**More info**

- Laravel version: 13.25.0 (regression introduced in 13.24.0)
- laravel-localization version: `master`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected registration of the translated route-list command.
  * Preserved its locale argument and standard route-list options.
  * Ensured package commands retain their own identities without overriding Laravel’s native commands.

* **Tests**
  * Added coverage for command registration, command identity, and inherited command options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->