### PR TITLE
Refactor: align route:trans:cache with the fluent definition approach

### DIFF
--- a/src/Mcamara/LaravelLocalization/Commands/RouteTranslationsCacheCommand.php
+++ b/src/Mcamara/LaravelLocalization/Commands/RouteTranslationsCacheCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Console\RouteCacheCommand;
 use Mcamara\LaravelLocalization\LaravelLocalization;
 use Mcamara\LaravelLocalization\Traits\TranslatedRouteCommandContext;
 use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Str;
 
 class RouteTranslationsCacheCommand extends RouteCacheCommand
 {
@@ -17,18 +18,28 @@ class RouteTranslationsCacheCommand extends RouteCacheCommand
     protected $name = 'route:trans:cache';
 
     /**
-     * The parent RouteCacheCommand declares `$signature = 'route:cache'`. Illuminate\Console\Command
-     * checks `$signature` before `$name`, so without overriding it here this command silently
-     * registers as `route:cache` instead of `route:trans:cache`, hijacking Laravel's native command.
-     *
-     * @var string
-     */
-    protected $signature = 'route:trans:cache';
-
-    /**
      * @var string
      */
     protected $description = 'Create a route cache file for faster route registration for all locales';
+
+
+    /**
+     * Configure the console command using a fluent definition.
+     *
+     * Laravel 13.24 moved RouteCacheCommand to a `$signature`, which takes precedence over
+     * `$name`, so without this the command registers itself as `route:cache`, hijacking
+     * Laravel's native command. Rewriting the inherited signature keeps the parent's
+     * arguments and options instead of restating them.
+     *
+     * @return void
+     */
+    #[\Override]
+    protected function configureUsingFluentDefinition()
+    {
+        $this->signature = Str::replaceFirst('route:cache', $this->name, $this->signature);
+
+        parent::configureUsingFluentDefinition();
+    }
 
 
     /**


### PR DESCRIPTION
Follow-up to #961 and #962, which fixed the same bug in two different ways.

Laravel 13.24 moved `RouteCacheCommand` and `RouteListCommand` from `$name` to `$signature`. Since `Illuminate\Console\Command::__construct()` checks `$signature` before `$name`, both package subclasses silently registered themselves under the parent's name, hijacking Laravel's native `route:cache` / `route:list`.

- #961 fixed the cache command by restating the signature: `protected $signature = 'route:trans:cache';`
- #962 fixed the list command by rewriting the command name inside the *inherited* signature from `configureUsingFluentDefinition()`, so the parent's twelve options are preserved rather than restated.

This PR moves the cache command onto #962's approach and drops the hardcoded `$signature`.

## Why, given #961 already works

Both are correct on every supported Laravel version today — `route:cache` declares no arguments or options on 11.x, 12.x or 13.x, so restating its signature loses nothing. The change is about what happens if that stops being true:

- `RouteTranslationsCacheCommand::handle()` still calls the inherited `getFreshApplicationRoutes()` and `getFreshApplication()`. Neither reads options today, but if a future version of either did `$this->option('...')` against a definition that never declared it, Symfony would throw `InvalidArgumentException` at runtime — silently, until someone actually ran `route:trans:cache`. Rewriting the inherited signature inherits whatever the parent declares, so it cannot drift.
- The rewrite is also a genuine no-op on Laravel 11/12, where the parent declares no `$signature` and `configureUsingFluentDefinition()` is never called. The hardcoded property instead *introduces* a signature on those versions, which forces the fluent path and skips `specifyParameters()`. Harmless here — nothing declares parameters — but it is a behavioural difference across versions that the override doesn't have.

Secondary benefit: one idiom for one failure mode across the two subclasses, with the reasoning stated once in each.

## Scope and limits

- Inheriting the parent's *definition* is not inheriting its *behaviour*. `handle()` is fully overridden and reads no options, so a new upstream flag would be accepted on the CLI and silently ignored. This converts a potential crash into a no-op; wiring a new flag into `cacheRoutesPerLocale()` would still be manual work.
- `RouteTranslationsClearCommand` needs no change — it extends plain `Illuminate\Console\Command`, which declares no `$signature`.
- No new tests. `CommandRegistrationTest`, added in #962, already covers the cache command's registration and asserts that Laravel's own `route:cache` is not hijacked. There is no equivalent of the list command's "keeps the parent's options" assertion because `route:cache` has no parameters to assert on — that property only becomes testable if Laravel adds one.
- Both files now share one latent fragility worth naming: the rewrite string-matches the parent's current name, so if Laravel ever renamed `route:cache` or `route:list`, `replaceFirst` would no-op and the command would quietly re-register under the parent's name. `CommandRegistrationTest` is what catches that.

## Testing

Full suite green locally: 148 tests, 221 assertions, on PHP 8.5.9 / Laravel 13.26.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route translation cache command configuration.
  * Preserved the standard route cache command’s arguments and options while registering the localized route cache command correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->